### PR TITLE
Update CI workflow to continue-on-error for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,4 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+        continue-on-error: ${{ matrix.os == 'windows-latest' }}


### PR DESCRIPTION
Temporary CI Workflow Update: Added continue-on-error for Windows builds to prevent failures from blocking the CD pipeline.