### PR TITLE
[workspace] Fix path normalization in makeDirectory test

### DIFF
--- a/packages/workspace/src/workspace/codebase/make-directory/index.test.ts
+++ b/packages/workspace/src/workspace/codebase/make-directory/index.test.ts
@@ -1,3 +1,4 @@
+import { normalize } from 'path';
 import { describe, expect, test } from 'vitest';
 
 import makeDirectory from '.';
@@ -7,13 +8,16 @@ import type { CodebaseOpts } from '../../../types';
 
 describe('Make Directory', () => {
   test('Everything works', async () => {
-    const files: [string, string][] = [1, 2, 3].map((x: number) => [`/home/projects/project/path${x}.ts`, '']);
+    const files: [string, string][] = [1, 2, 3].map((x: number) => [
+      normalize(`/home/projects/project/path${x}.ts`),
+      '',
+    ]);
     const pipeline: Function[] = [];
 
     const opts: CodebaseOpts = {
       pipeline,
       files,
-      src: '/home/projects/project/',
+      src: normalize('/home/projects/project/'),
       extensions: [],
       ignoredFiles: [],
       ignoredImports: [],
@@ -23,6 +27,6 @@ describe('Make Directory', () => {
     const codebase = new Codebase(opts);
     const file = codebase.extractFiles()[0];
     const newSrc = makeDirectory(codebase, file);
-    expect(newSrc).toBe('/project/path1/index.ts');
+    expect(normalize(newSrc)).toBe(normalize('/project/path1/index.ts'));
   });
 });


### PR DESCRIPTION
This pull request addresses an issue with the `makeDirectory` test, which was failing on Windows due to differences in path separators.

Progressing with issue #4.

