### PR TITLE
[workspace] Use classes for types

### DIFF
--- a/packages/workspace/src/types.ts
+++ b/packages/workspace/src/types.ts
@@ -1,5 +1,7 @@
+import type FileContainer from './workspace/codebase/file';
+
 export interface RandomObject extends Record<string, any> {}
-export interface FilesContainer extends Record<string, FileContainerType> {}
+export interface FilesContainer extends Record<string, FileContainer> {}
 
 export type Options = {
   pipeline?: Function[];
@@ -22,48 +24,6 @@ export interface CodebaseOpts extends Options {
 
 export type WorkspaceType = {
   opts: WorkspaceOpts;
-};
-
-export type CodebaseType = {
-  src: string;
-  extensions: string[];
-  ignoredFiles: string[];
-  ignoredImports: string[];
-  files: FilesContainer;
-  rootName: string;
-  srcWithoutRoot: string;
-  package: PackageContents;
-  dependencies: string[];
-  opts: Options;
-  replaceRoot: Function;
-  saveFile: Function;
-  fromJson: Function;
-  extractFiles: Function;
-  save: Function;
-  addFile: Function;
-  makeDirectory: Function;
-};
-
-// TODO: Use more explicit types (avoid the use of Function)
-export type FileContainerType = {
-  pathname: string;
-  fullPath: string;
-  type?: string;
-  code: string;
-  simple: Boolean;
-  hasParent: Boolean;
-  codebase: CodebaseType;
-  store: FileStore;
-  ast?: any;
-  parse: Function;
-  updateCode: Function;
-  print: Function;
-  astToCode: Function;
-  codeToAST: Function;
-  spawn: Function;
-  tooSimple: Function;
-  addImport: (importStatement?: any) => boolean;
-  save: Function;
 };
 
 export type Custom = {

--- a/packages/workspace/src/workspace/codebase/file/index.ts
+++ b/packages/workspace/src/workspace/codebase/file/index.ts
@@ -1,6 +1,7 @@
 import { dirname } from 'path';
 
-import type { CodebaseType, FileStore } from '../../../types';
+import type Codebase from '..';
+import type { FileStore } from '../../../types';
 
 interface ProvisionalFile {
   pathname: string;
@@ -21,13 +22,13 @@ export default class FileContainer {
 
   hasParent: Boolean;
 
-  codebase: CodebaseType;
+  codebase: Codebase;
 
   store: FileStore;
 
   ast?: any;
 
-  constructor(path: string, code: string, codebase: CodebaseType) {
+  constructor(path: string, code: string, codebase: Codebase) {
     this.codebase = codebase;
     this.pathname = codebase.replaceRoot(path);
     this.fullPath = path;
@@ -47,7 +48,7 @@ export default class FileContainer {
     return {};
   }
 
-  astToCode(ast: any) {
+  astToCode(ast?: any) {
     return '';
   }
 

--- a/packages/workspace/src/workspace/codebase/index.ts
+++ b/packages/workspace/src/workspace/codebase/index.ts
@@ -1,12 +1,13 @@
 import { basename, dirname } from 'path';
 
 import copy from './copy';
+import type { default as FileContainerType } from './file';
 import FileContainer from './file';
 import makeDirectory from './make-directory';
 import { fromFile, fromJson, saveFile, saveToJSON, toFile } from './save';
 import storeDependencies from './store-dependencies';
 
-import type { CodebaseOpts, FileContainerType, FilesContainer, PackageContents, RandomObject } from '../../types';
+import type { CodebaseOpts, FilesContainer, PackageContents, RandomObject } from '../../types';
 
 export default class Codebase {
   src: string;

--- a/packages/workspace/src/workspace/codebase/make-directory/index.ts
+++ b/packages/workspace/src/workspace/codebase/make-directory/index.ts
@@ -1,8 +1,9 @@
 import { basename, dirname, join } from 'path';
 
-import type { CodebaseType, FileContainerType } from '../../../types';
+import type Codebase from '..';
+import type FileContainer from '../file';
 
-export default (codebase: CodebaseType, file: FileContainerType) => {
+export default (codebase: Codebase, file: FileContainer) => {
   const filename = basename(file.pathname);
 
   const filenamePieces = filename.split('.');

--- a/packages/workspace/src/workspace/codebase/save/index.ts
+++ b/packages/workspace/src/workspace/codebase/save/index.ts
@@ -1,7 +1,9 @@
 import fs from 'fs';
 import { dirname } from 'path';
 
-import type { CodebaseType, FileContainerType, RandomObject } from '../../../types';
+import type Codebase from '..';
+import type { RandomObject } from '../../../types';
+import FileContainer from '../file';
 
 const createFile = (pathname: string, contents: string) => {
   fs.createWriteStream(pathname).write(contents);
@@ -30,7 +32,7 @@ export const saveToJSON = (pathname: string, data: RandomObject) => {
   createDir(pathname, toJson(data));
 };
 
-export const fromFile = (pathname: string, codebase: CodebaseType) => {
+export const fromFile = (pathname: string, codebase: Codebase) => {
   fs.readFile(pathname, { encoding: 'utf-8' }, function (err: NodeJS.ErrnoException | null, data: string) {
     if (err) {
       console.error(err);
@@ -45,7 +47,7 @@ export const fromFile = (pathname: string, codebase: CodebaseType) => {
   });
 };
 
-export const toFile = (file: FileContainerType) => {
+export const toFile = (file: FileContainer) => {
   const { pathname: path, code } = file;
   createDir(path, code);
 };

--- a/packages/workspace/src/workspace/codebase/store-dependencies/index.ts
+++ b/packages/workspace/src/workspace/codebase/store-dependencies/index.ts
@@ -1,6 +1,6 @@
-import type { CodebaseType } from '../../../types';
+import type Codebase from '..';
 
-export default (codebase: CodebaseType, dependencyKeys: string[]) => {
+export default (codebase: Codebase, dependencyKeys: string[]) => {
   const dependencies: Map<string, string> = new Map();
   dependencyKeys.forEach((key: string) => {
     if (codebase.package[key]) {

--- a/packages/workspace/src/workspace/index.test.ts
+++ b/packages/workspace/src/workspace/index.test.ts
@@ -85,6 +85,7 @@ describe('Workspace base', () => {
     ];
     expect(JSON.stringify(output)).toBe(JSON.stringify(result));
   }, 8000);
+
   test('Default options adds an empty array for files', async () => {
     const output: OutputIteration[] = [];
     const opts: WorkspaceOpts = {

--- a/packages/workspace/src/workspace/index.ts
+++ b/packages/workspace/src/workspace/index.ts
@@ -1,7 +1,8 @@
 import { readDirectory } from '@modular-rocks/traverse-files';
 import runPipeline from './pipeline';
 
-import type { FileContainerType, WorkspaceOpts } from '../types';
+import type { WorkspaceOpts } from '../types';
+import type FileContainer from './codebase/file';
 
 export default class Workspace {
   opts: WorkspaceOpts;
@@ -17,7 +18,7 @@ export default class Workspace {
     }
   }
 
-  async pipeline(files: FileContainerType[], pipeline: Function[] | undefined, opts: WorkspaceOpts) {
+  async pipeline(files: FileContainer[], pipeline: Function[] | undefined, opts: WorkspaceOpts) {
     return runPipeline(files, pipeline, opts, this);
   }
 }

--- a/packages/workspace/src/workspace/pipeline/index.ts
+++ b/packages/workspace/src/workspace/pipeline/index.ts
@@ -1,6 +1,7 @@
-import type { FileContainerType, State, WorkspaceOpts, WorkspaceType } from '../../types';
+import type { State, WorkspaceOpts, WorkspaceType } from '../../types';
+import type FileContainer from '../codebase/file';
 
-function wait(func: Function, file: FileContainerType, state: State, opts: WorkspaceOpts, workspace: WorkspaceType) {
+function wait(func: Function, file: FileContainer, state: State, opts: WorkspaceOpts, workspace: WorkspaceType) {
   return new Promise(async (resolve, reject) => {
     try {
       const result = await func(file, state, opts, workspace);
@@ -13,17 +14,17 @@ function wait(func: Function, file: FileContainerType, state: State, opts: Works
 
 const invoke = async (
   func: Function,
-  files: FileContainerType[],
+  files: FileContainer[],
   state: State,
   opts: WorkspaceOpts,
   workspace: WorkspaceType
 ) => {
-  const promises = files.map((file: FileContainerType) => wait(func, file, state, opts, workspace));
+  const promises = files.map((file: FileContainer) => wait(func, file, state, opts, workspace));
   return Promise.all(promises);
 };
 
 const promise = async (
-  files: FileContainerType[],
+  files: FileContainer[],
   pipeline: Function[],
   opts: WorkspaceOpts,
   workspace: WorkspaceType,
@@ -41,7 +42,7 @@ const promise = async (
 };
 
 export default async (
-  files: FileContainerType[],
+  files: FileContainer[],
   pipeline: Function[] | undefined,
   opts: WorkspaceOpts,
   workspace: WorkspaceType


### PR DESCRIPTION
This pull request focuses on enhancing the codebase's type structure by utilizing existing class definitions to replace previously defined type objects.

By leveraging the existing class definitions, we not only reduce redundancy but also align the types more closely with the actual implementation. This alignment helps in maintaining consistency and enables better tooling support within modern IDEs.
