### PR TITLE
Temporary fix for vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,10 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/modular-rocks/slimfast-turbo.git"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "vitest@0.34.1": "patches/vitest@0.34.1.patch"
+    }
   }
 }

--- a/patches/vitest@0.34.1.patch
+++ b/patches/vitest@0.34.1.patch
@@ -1,0 +1,12 @@
+diff --git a/dist/vendor-node.caa511fc.js b/dist/vendor-node.caa511fc.js
+index e11a4b8137f9486f878fb6c3da4b0067edd6a3e9..487775f1532e01445d6ea35a851457e482c76c0a 100644
+--- a/dist/vendor-node.caa511fc.js
++++ b/dist/vendor-node.caa511fc.js
+@@ -10511,6 +10511,7 @@ function getWorkerMemoryLimit(config) {
+   return 1 / (config.maxThreads ?? getDefaultThreadsCount(config));
+ }
+ function stringToBytes(input, percentageReference) {
++  percentageReference = percentageReference || 100;
+   if (input === null || input === void 0)
+     return input;
+   if (typeof input === "string") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  vitest@0.34.1:
+    hash: 5xnszfiqfuv3ia5tua4n3tgnlu
+    path: patches/vitest@0.34.1.patch
+
 importers:
 
   .:
@@ -73,7 +78,7 @@ importers:
         version: 5.1.6
       vitest:
         specifier: 0.34.1
-        version: 0.34.1
+        version: 0.34.1(patch_hash=5xnszfiqfuv3ia5tua4n3tgnlu)
 
   config/jest-config: {}
 
@@ -2580,7 +2585,7 @@ packages:
       std-env: 3.3.3
       test-exclude: 6.0.0
       v8-to-istanbul: 9.1.0
-      vitest: 0.34.1
+      vitest: 0.34.1(patch_hash=5xnszfiqfuv3ia5tua4n3tgnlu)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7467,7 +7472,7 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest@0.34.1:
+  /vitest@0.34.1(patch_hash=5xnszfiqfuv3ia5tua4n3tgnlu):
     resolution: {integrity: sha512-G1PzuBEq9A75XSU88yO5G4vPT20UovbC/2osB2KEuV/FisSIIsw7m5y2xMdB7RsAGHAfg2lPmp2qKr3KWliVlQ==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -7531,6 +7536,7 @@ packages:
       - supports-color
       - terser
     dev: true
+    patched: true
 
   /walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}


### PR DESCRIPTION
This pull request introduces a provisional solution for integrating Vitest with Stackblitz's Codeflow.
The issue appears to be from the absence of a default value [here](https://github.com/vitest-dev/vitest/blob/f4e6e99fa3a81fd7a97fb9b435da367dddba7fa4/packages/vitest/src/utils/memory-limit.ts#L27). 

Without this change, it throws this error:
`Error: For a percentage based memory limit a percentageReference must be supplied`
`ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL`

