### PR TITLE
[workspace] Use named exports

### DIFF
--- a/config/eslint-config/.eslintrc.cjs
+++ b/config/eslint-config/.eslintrc.cjs
@@ -39,8 +39,8 @@ module.exports = {
     'no-async-promise-executor': 'off',
     '@typescript-eslint/no-useless-constructor': 'off',
     'import/no-cycle': 'off',
-    // needed for the monorepo
-    'import/no-extraneous-dependencies': 'off',
+    'import/no-extraneous-dependencies': 'off', // needed for the monorepo
+    'import/prefer-default-export': 'off',
   },
 
   ignorePatterns: ['.eslintrc.cjs', 'jest.config.js', 'dist', 'turbo', 'coverage'],

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -1,7 +1,6 @@
-import Workspace from './workspace';
-import FileContainer from './workspace/codebase/file';
-import Codebase from './workspace/codebase';
-import pipeline from './workspace/pipeline';
+import { Workspace } from './workspace';
+import { Codebase } from './workspace/codebase';
+import { FileContainer } from './workspace/codebase/file';
+import { pipeline } from './workspace/pipeline';
 
-export { Workspace, FileContainer, Codebase, pipeline };
-export default Workspace;
+export { Codebase, FileContainer, Workspace, pipeline };

--- a/packages/workspace/src/types.ts
+++ b/packages/workspace/src/types.ts
@@ -1,7 +1,7 @@
-import type FileContainer from './workspace/codebase/file';
+import type { FileContainer } from './workspace/codebase/file';
 
-export interface RandomObject extends Record<string, any> {}
-export interface FilesContainer extends Record<string, FileContainer> {}
+export type RandomObject = Record<string, any>;
+export type FilesContainer = Record<string, FileContainer>;
 
 export type Options = {
   pipeline?: Function[];
@@ -27,7 +27,7 @@ export type WorkspaceType = {
 };
 
 export type Custom = {
-  [propter: string]: any;
+  [property: string]: any;
 };
 
 export type State = {
@@ -40,7 +40,7 @@ export type FileStore = {
   [property: string]: any;
 };
 
-// Can take any shape, generately has to be an Object like Node packages
+// Can take any shape, generally has to be an Object like Node packages
 // Ports to any other languages can be formatted
 export type PackageContents = {
   [property: string]: any;

--- a/packages/workspace/src/workspace/codebase/copy/index.test.ts
+++ b/packages/workspace/src/workspace/codebase/copy/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import copy from '.';
+import { copy } from '.';
 
 const str = JSON.stringify;
 

--- a/packages/workspace/src/workspace/codebase/copy/index.ts
+++ b/packages/workspace/src/workspace/codebase/copy/index.ts
@@ -1,7 +1,5 @@
 import type { RandomObject } from '../../../types';
 
-export default (localObject: RandomObject, foreignObject: RandomObject) => {
-  Object.keys(foreignObject).forEach((path: string) => {
-    localObject[path] = foreignObject[path];
-  });
+export const copy = (localObject: RandomObject, foreignObject: RandomObject) => {
+  Object.assign(localObject, foreignObject);
 };

--- a/packages/workspace/src/workspace/codebase/file/index.test.ts
+++ b/packages/workspace/src/workspace/codebase/file/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import Codebase from '..';
+import { Codebase } from '..';
 
 import type { CodebaseOpts } from '../../../types';
 

--- a/packages/workspace/src/workspace/codebase/file/index.ts
+++ b/packages/workspace/src/workspace/codebase/file/index.ts
@@ -1,15 +1,15 @@
 import { dirname } from 'path';
 
-import type Codebase from '..';
+import type { Codebase } from '..';
 import type { FileStore } from '../../../types';
 
-interface ProvisionalFile {
+export type ProvisionalFile = {
   pathname: string;
   ast: any;
   import: any;
-}
+};
 
-export default class FileContainer {
+export class FileContainer {
   pathname: string;
 
   fullPath: string;

--- a/packages/workspace/src/workspace/codebase/index.test.ts
+++ b/packages/workspace/src/workspace/codebase/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import Codebase from '.';
+import { Codebase } from '.';
 
 import type { CodebaseOpts } from '../../types';
 

--- a/packages/workspace/src/workspace/codebase/index.ts
+++ b/packages/workspace/src/workspace/codebase/index.ts
@@ -1,15 +1,15 @@
 import { basename, dirname } from 'path';
 
-import copy from './copy';
-import type FileContainerType from './file';
-import FileContainer from './file';
-import makeDirectory from './make-directory';
+import { copy } from './copy';
+import type { FileContainer as FileContainerType } from './file';
+import { FileContainer } from './file';
+import { makeDirectory } from './make-directory';
 import { fromFile, fromJson, saveFile, saveToJSON, toFile } from './save';
-import storeDependencies from './store-dependencies';
+import { storeDependencies } from './store-dependencies';
 
 import type { CodebaseOpts, FilesContainer, PackageContents, RandomObject } from '../../types';
 
-export default class Codebase {
+export class Codebase {
   src: string;
 
   extensions: string[];

--- a/packages/workspace/src/workspace/codebase/make-directory/index.test.ts
+++ b/packages/workspace/src/workspace/codebase/make-directory/index.test.ts
@@ -1,8 +1,8 @@
 import { normalize } from 'path';
 import { describe, expect, test } from 'vitest';
 
-import makeDirectory from '.';
-import Codebase from '..';
+import { makeDirectory } from '.';
+import { Codebase } from '..';
 
 import type { CodebaseOpts } from '../../../types';
 

--- a/packages/workspace/src/workspace/codebase/make-directory/index.ts
+++ b/packages/workspace/src/workspace/codebase/make-directory/index.ts
@@ -1,9 +1,9 @@
 import { basename, dirname, join } from 'path';
 
-import type Codebase from '..';
-import type FileContainer from '../file';
+import type { Codebase } from '..';
+import type { FileContainer } from '../file';
 
-export default (codebase: Codebase, file: FileContainer) => {
+export const makeDirectory = (codebase: Codebase, file: FileContainer) => {
   const filename = basename(file.pathname);
 
   const filenamePieces = filename.split('.');

--- a/packages/workspace/src/workspace/codebase/save/index.ts
+++ b/packages/workspace/src/workspace/codebase/save/index.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import { dirname } from 'path';
 
-import type Codebase from '..';
+import type { Codebase } from '..';
 import type { RandomObject } from '../../../types';
-import FileContainer from '../file';
+import type { FileContainer } from '../file';
 
 const createFile = (pathname: string, contents: string) => {
   fs.createWriteStream(pathname).write(contents);

--- a/packages/workspace/src/workspace/codebase/store-dependencies/index.test.ts
+++ b/packages/workspace/src/workspace/codebase/store-dependencies/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
-import storeDependencies from '.';
-import Codebase from '..';
+import { storeDependencies } from '.';
+import { Codebase } from '..';
 
 import type { CodebaseOpts } from '../../../types';
 

--- a/packages/workspace/src/workspace/codebase/store-dependencies/index.ts
+++ b/packages/workspace/src/workspace/codebase/store-dependencies/index.ts
@@ -1,6 +1,6 @@
-import type Codebase from '..';
+import type { Codebase } from '..';
 
-export default (codebase: Codebase, dependencyKeys: string[]) => {
+export const storeDependencies = (codebase: Codebase, dependencyKeys: string[]) => {
   const dependencies: Map<string, string> = new Map();
   dependencyKeys.forEach((key: string) => {
     if (codebase.package[key]) {

--- a/packages/workspace/src/workspace/index.test.ts
+++ b/packages/workspace/src/workspace/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
-import Workspace from '.';
-import Codebase from './codebase';
+import { Workspace } from '.';
+import { Codebase } from './codebase';
 
 import type { CodebaseOpts, OutputIteration, WorkspaceOpts } from '../types';
 

--- a/packages/workspace/src/workspace/index.ts
+++ b/packages/workspace/src/workspace/index.ts
@@ -1,10 +1,10 @@
 import { readDirectory } from '@modular-rocks/traverse-files';
-import runPipeline from './pipeline';
+import { pipeline as runPipeline } from './pipeline';
 
 import type { WorkspaceOpts } from '../types';
-import type FileContainer from './codebase/file';
+import type { FileContainer } from './codebase/file';
 
-export default class Workspace {
+export class Workspace {
   opts: WorkspaceOpts;
 
   constructor(opts: WorkspaceOpts) {

--- a/packages/workspace/src/workspace/pipeline/index.test.ts
+++ b/packages/workspace/src/workspace/pipeline/index.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'vitest';
 
-import runPipeline from '.';
-import Workspace from '..';
-import Codebase from '../codebase';
+import { pipeline as runPipeline } from '.';
+import { Workspace } from '..';
+import { Codebase } from '../codebase';
 
 import type { CodebaseOpts, OutputIteration, WorkspaceOpts } from '../../types';
 

--- a/packages/workspace/src/workspace/pipeline/index.ts
+++ b/packages/workspace/src/workspace/pipeline/index.ts
@@ -1,5 +1,5 @@
 import type { State, WorkspaceOpts, WorkspaceType } from '../../types';
-import type FileContainer from '../codebase/file';
+import type { FileContainer } from '../codebase/file';
 
 function wait(func: Function, file: FileContainer, state: State, opts: WorkspaceOpts, workspace: WorkspaceType) {
   return new Promise(async (resolve, reject) => {
@@ -41,15 +41,15 @@ const promise = async (
   resolve();
 };
 
-export default async (
+export const pipeline = async (
   files: FileContainer[],
-  pipeline: Function[] | undefined,
+  pipelineFunctions: Function[] | undefined,
   opts: WorkspaceOpts,
   workspace: WorkspaceType
 ) => {
-  if (!pipeline) return false;
+  if (!pipelineFunctions) return false;
 
   return new Promise((resolve) => {
-    promise(files, pipeline, opts, workspace, resolve);
+    promise(files, pipelineFunctions, opts, workspace, resolve);
   });
 };


### PR DESCRIPTION
We're migrating from default exports to named exports in the `workspace` package with this PR.
