### PR TITLE
[workspace]: Add jsdocs

### DIFF
--- a/config/eslint-config/.eslintrc.cjs
+++ b/config/eslint-config/.eslintrc.cjs
@@ -41,6 +41,7 @@ module.exports = {
     'import/no-cycle': 'off',
     'import/no-extraneous-dependencies': 'off', // needed for the monorepo
     'import/prefer-default-export': 'off',
+    '@typescript-eslint/no-floating-promises': 'error',
   },
 
   ignorePatterns: ['.eslintrc.cjs', 'jest.config.js', 'dist', 'turbo', 'coverage'],

--- a/packages/workspace/src/types.ts
+++ b/packages/workspace/src/types.ts
@@ -14,13 +14,13 @@ export type Options = {
   custom?: Custom;
 };
 
-export interface WorkspaceOpts extends Options {
+export type WorkspaceOpts = Options & {
   files?: [string, string][];
-}
+};
 
-export interface CodebaseOpts extends Options {
+export type CodebaseOpts = Options & {
   files: [string, string][];
-}
+};
 
 export type WorkspaceType = {
   opts: WorkspaceOpts;

--- a/packages/workspace/src/workspace/codebase/copy/index.ts
+++ b/packages/workspace/src/workspace/codebase/copy/index.ts
@@ -1,5 +1,16 @@
 import type { RandomObject } from '../../../types';
 
+/**
+ * Merges properties from the `foreignObject` into the `localObject`.
+ *
+ * @param localObject - The target object to which properties are added.
+ * @param foreignObject - The source object from which properties are copied.
+ * @example
+ * const source = { text: 'hello world' };
+ * const target = { sample: 'text' };
+ * copy(target, source);
+ * console.log(target); // Outputs: { sample: 'text', text: 'hello world' }
+ */
 export const copy = (localObject: RandomObject, foreignObject: RandomObject) => {
   Object.assign(localObject, foreignObject);
 };

--- a/packages/workspace/src/workspace/codebase/file/index.ts
+++ b/packages/workspace/src/workspace/codebase/file/index.ts
@@ -30,7 +30,7 @@ export class FileContainer {
    */
   fullPath: string;
 
-  // TODO: write example
+  // TODO: add example
   /**
    * Can be used to store the semantic type of module for your system; if you're defining modules semantically differently to one another, then you can group files by semantic type and store the module type here.
    */
@@ -46,7 +46,6 @@ export class FileContainer {
    */
   code: string;
 
-  // TODO: double check example
   /**
    * Stores information about the simplicity of the AST in the file. Using another function, the quality of the AST can be measured using metrics and determined to be a simple piece of code or a complex piece of code.
    *
@@ -83,7 +82,7 @@ export class FileContainer {
    */
   codebase: Codebase;
 
-  // TODO: double check example
+  // TODO: add example
   /**
    * General store for storing any type of data associated to the file. Mostly used during the pipeline enumeration where you may wish to store data scoped to the specific file that is retrievable later.
    */
@@ -234,12 +233,10 @@ export class FileContainer {
    * const newFile = existingFileContainer.spawn(provisionalFile);
    * console.log(newFile.pathname); // Outputs: '/path/to/new/file.js'
    */
-  // TODO: is the type of `file` correct? FileContainer expects `codebase` to be a Codebase instance
   spawn(file: ProvisionalFile) {
     return new FileContainer(file.pathname, this.print(file.ast), this.codebase);
   }
 
-  // TODO: I'm not sure what this method is supposed to do
   /**
    * Should add an import statement to the file?
    *

--- a/packages/workspace/src/workspace/codebase/file/index.ts
+++ b/packages/workspace/src/workspace/codebase/file/index.ts
@@ -10,24 +10,107 @@ export type ProvisionalFile = {
 };
 
 export class FileContainer {
+  /**
+   * The relative path of the file within the codebase, excluding the root directory.
+   *
+   * @example
+   * // For a codebase with a root of `/home/projects` and a file at `/home/projects/project/file1.js`:
+   * const file = new FileContainer('/home/projects/project/file1.js', 'console.log("hello world")', codebase);
+   * console.log(file.pathname); // Outputs: '/project/file1.js'
+   */
   pathname: string;
 
+  /**
+   * The absolute path of the file within the file system.
+   *
+   * @example
+   * // For a codebase with a root of `/home/projects` and a file at `/home/projects/project/file1.js`:
+   * const file = new FileContainer('/home/projects/project/file1.js', 'console.log("hello world")', codebase);
+   * console.log(file.fullPath); // Outputs: '/home/projects/project/file1.js'
+   */
   fullPath: string;
 
+  // TODO: write example
+  /**
+   * Can be used to store the semantic type of module for your system; if you're defining modules semantically differently to one another, then you can group files by semantic type and store the module type here.
+   */
   type?: string;
 
+  /**
+   * The content of the file represented as a string. It holds the actual code or data within the file.
+   *
+   * @example
+   * // For a file with the content "console.log('Hello, World!');":
+   * const file = new FileContainer('/home/projects/project/path1', 'console.log("hello world");', codebase);
+   * console.log(file.code); // Outputs: 'console.log("Hello World");'
+   */
   code: string;
 
+  // TODO: double check example
+  /**
+   * Stores information about the simplicity of the AST in the file. Using another function, the quality of the AST can be measured using metrics and determined to be a simple piece of code or a complex piece of code.
+   *
+   * @example
+   * const file = new FileContainer('/home/projects/project/path1', '', codebase);
+   * console.log(file.simple);
+   * // Outputs: true of false
+   */
   simple: Boolean;
 
+  /**
+   * Indicates whether the file has a parent directory other than the root or current directory.
+   * If the parent directory is either root or current, the property is `false`. Otherwise, it's `true`.
+   *
+   * @example
+   * // For a codebase with a root of `/home/projects` and a file at `/home/projects/project/file1.js`:
+   * const file = new FileContainer('/home/projects/project/file1.js', 'console.log("hello world")', codebase);
+   * console.log(file.hasParent); // Outputs: true
+   * // For a codebase with a root of `/home/projects` and a file at `/home/projects/file1.js`:
+   * const file = new FileContainer('/home/projects/file1.js', 'console.log("hello world")', codebase);
+   * console.log(file.hasParent); // Outputs: false
+   */
   hasParent: Boolean;
 
+  /**
+   * Represents the codebase to which this file belongs. The codebase contains metadata
+   * and utilities that might be used for file manipulations, parsing, saving, and other
+   * operations related to the file.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const file = new FileContainer('/home/projects/project/file1.js', 'console.log("hello world")', codebase);
+   * console.log(file.codebase); // Outputs: Instance of Codebase
+   */
   codebase: Codebase;
 
+  // TODO: double check example
+  /**
+   * General store for storing any type of data associated to the file. Mostly used during the pipeline enumeration where you may wish to store data scoped to the specific file that is retrievable later.
+   */
   store: FileStore;
 
+  /**
+   * Represents the Abstract Syntax Tree (AST) of the file's content. The AST provides a structured
+   * representation of the source code, making it easier to analyze, manipulate, and generate code.
+   * This property is populated after parsing the file's content.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const file = new FileContainer('/home/projects/project/file1.js', 'console.log("hello world")', codebase);
+   * file.parse();
+   * console.log(file.ast); // Outputs: AST representation of 'console.log("hello world")'
+   */
   ast?: any;
 
+  /**
+   * @param path - The absolute path of the file within the file system.
+   * @param code - The content of the file represented as a string.
+   * @param codebase - The codebase to which this file belongs.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const file = new FileContainer('/home/projects/project/file1.js', 'console.log("hello world")', codebase);
+   */
   constructor(path: string, code: string, codebase: Codebase) {
     this.codebase = codebase;
     this.pathname = codebase.replaceRoot(path);
@@ -40,24 +123,93 @@ export class FileContainer {
     this.hasParent = !['/', '.'].includes(parentPath);
   }
 
+  /**
+   * Determines if the content of the file is too simple based on specific criteria.
+   * In the current implementation, this method always returns `false`.
+   *
+   * @returns Returns `true` if the file's content is considered too simple; otherwise, returns `false`.
+   *
+   * @example
+   * const file = new FileContainer('/home/projects/project/file1.js', 'console.log("hello world")', codebase);
+   * console.log(file.tooSimple()); // Outputs: false
+   */
   tooSimple(): Boolean {
     return false;
   }
 
+  /**
+   * Converts the file's content (source code) into its Abstract Syntax Tree (AST) representation.
+   *
+   * This method acts as a placeholder and should be implemented to parse the file's content
+   * into a meaningful AST based on the language or structure of the file.
+   *
+   * @returns The AST representation of the file's content. In the current implementation, it returns an empty object.
+   *
+   * @example
+   * const file = new FileContainer('/home/projects/project/file1.js', 'console.log("hello world")', codebase);
+   * const ast = file.codeToAST();
+   * console.log(ast); // Outputs: {}
+   */
   codeToAST() {
     return {};
   }
 
+  /**
+   * Converts the provided Abstract Syntax Tree (AST) back into its string representation (source code).
+   *
+   * This method acts as a placeholder and should be implemented to generate source code
+   * from a given AST based on the language or structure of the file.
+   *
+   * @param ast - The AST representation of the file's content to be converted back to source code.
+   * If not provided, it should assume the file's current AST.
+   * @returns The string representation (source code) of the provided AST.
+   * In the current implementation, it always returns an empty string.
+   *
+   * @example
+   * const file = new FileContainer('/home/projects/project/file1.js', 'console.log("hello world")', codebase);
+   * const code = file.astToCode();
+   * console.log(code); // Outputs: ''
+   */
   astToCode(ast?: any) {
     return '';
   }
 
+  /**
+   * Parses the file's content into its Abstract Syntax Tree (AST) representation
+   * and determines if the content is too simple.
+   *
+   * If the AST already exists and the content is marked as simple,
+   * the method will exit early without reparsing.
+   * Otherwise, it will parse the content into an AST and check for its simplicity.
+   *
+   * @example
+   * const file = new FileContainer('/path/to/file.js', 'const a = 1;', codebase);
+   * file.parse();
+   * console.log(file.ast); // Outputs: AST representation of 'const a = 1;'
+   */
   parse() {
     if (this.ast && this.simple) return;
     this.ast = this.codeToAST();
     this.simple = this.tooSimple();
   }
 
+  /**
+   * Converts the file's Abstract Syntax Tree (AST) back into its string representation.
+   *
+   * If an AST is provided as an argument, it will use that AST for the conversion.
+   * If no AST is provided and the current file instance doesn't have an existing AST,
+   * it will first parse the file's content to generate the AST and then convert it
+   * into its string representation.
+   *
+   * @param ast - An optional AST to be converted. If not provided, the method uses the file's current AST.
+   * @returns The string representation of the AST, which is the source code.
+   *
+   * @example
+   * const file = new FileContainer('/path/to/file.js', 'const a = 1;', codebase);
+   * const codeString = file.print();
+   * console.log(codeString);
+   * // Expected output (based on current implementation): ''
+   */
   print(ast?: any) {
     if (ast) {
       return this.astToCode(ast);
@@ -66,20 +218,73 @@ export class FileContainer {
     return this.astToCode(this.ast);
   }
 
+  /**
+   * Creates and returns a new instance of the `FileContainer` class using the provided `file` data.
+   *
+   * The new instance is created using the `pathname` from the provided `file`,
+   * the string representation of its AST (using the current `FileContainer`'s `print` method),
+   * and the current `FileContainer`'s `codebase`.
+   *
+   *
+   * @returns Returns a new instance of the `FileContainer` class.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const provisionalFile = { pathname: '/path/to/new/file.js', ast: {}, codebase };
+   * const newFile = existingFileContainer.spawn(provisionalFile);
+   * console.log(newFile.pathname); // Outputs: '/path/to/new/file.js'
+   */
+  // TODO: is the type of `file` correct? FileContainer expects `codebase` to be a Codebase instance
   spawn(file: ProvisionalFile) {
     return new FileContainer(file.pathname, this.print(file.ast), this.codebase);
   }
 
-  // TODO: Double check this
+  // TODO: I'm not sure what this method is supposed to do
+  /**
+   * Should add an import statement to the file?
+   *
+   * This method is currently a placeholder and always returns `false`, indicating that the import was not added.
+   * In a more complete implementation, it might modify the file's content to include the provided import statement.
+   *
+   * @param importStatement - The import statement or data to be added to the file.
+   * @returns Returns `true` if the import was successfully added; otherwise, returns `false`.
+   *
+   * @example
+   * const file = new FileContainer('/path/to/file.js', 'console.log("Hello");', codebase);
+   * const result = file.addImport('import { hello } from "./hello";');
+   * console.log(result); // Outputs: false
+   */
   addImport(importStatement?: any) {
     return false;
   }
 
+  /**
+   * Updates the `code` property of the FileContainer instance with the string representation of its AST.
+   *
+   * This method first converts the current AST (Abstract Syntax Tree) of the file to its source code representation
+   * using the `print` method. It then updates the `code` property of the FileContainer instance with this representation.
+   *
+   * @example
+   * const file = new FileContainer('/path/to/file.js', 'console.log("Hello");', codebase);
+   * file.updateCode();
+   * console.log(file.code);
+   * // Depending on the implementation of `print`, this might output: 'console.log("Hello");'
+   */
   updateCode() {
     this.code = this.print();
   }
 
+  /**
+   * Saves the current content of the `File` instance to the file system using its associated `Codebase` instance.
+   * The file is saved at the location specified by the `pathname` property of the `File` instance,
+   * and its content will be the value of the `code` property of this `File` instance.
+   *
+   * @example
+   * const file = new File(codebase, '/path/to/script.js', 'console.log("Hello World");');
+   * await file.save();
+   * // The file is saved at '/path/to/script.js' with the content 'console.log("Hello World");'
+   */
   save() {
-    this.codebase.saveFile(this.pathname, this.code);
+    return this.codebase.saveFile(this.pathname, this.code);
   }
 }

--- a/packages/workspace/src/workspace/codebase/index.ts
+++ b/packages/workspace/src/workspace/codebase/index.ts
@@ -4,32 +4,259 @@ import { copy } from './copy';
 import type { FileContainer as FileContainerType } from './file';
 import { FileContainer } from './file';
 import { makeDirectory } from './make-directory';
-import { fromFile, fromJson, saveFile, saveToJSON, toFile } from './save';
+import { fromFile, fromJson, saveFile, saveToJSON } from './save';
 import { storeDependencies } from './store-dependencies';
 
 import type { CodebaseOpts, FilesContainer, PackageContents, RandomObject } from '../../types';
 
 export class Codebase {
+  /**
+   * Represents the root directory of the codebase, providing the absolute path to where the files are located.
+   *
+   * The `src` property holds the absolute path to the root directory of the codebase. It serves as a reference
+   * point for various operations within the `Codebase` class, such as storing, retrieving, and manipulating files.
+   *
+   * @example
+   * const opts: CodebaseOpts = {
+   *   // ... other options
+   *   src: '/home/projects/project/'
+   * };
+   * const codebase = new Codebase(opts);
+   * console.log(codebase.src);
+   * // Outputs: '/home/projects/project/'
+   */
   src: string;
 
+  /**
+   * An array of file extensions that the codebase considers for processing.
+   *
+   * The `extensions` property contains a list of file extensions that determine which files in the
+   * codebase are relevant for various operations, such as parsing or transformation. Files with extensions
+   * not listed in this array may be ignored or excluded from certain processes.
+   *
+   * Extensions in this array should include the leading dot (e.g., `.js`, `.ts`).
+   *
+   * @example
+   * const opts: CodebaseOpts = {
+   *   // ... other options
+   *   extensions: ['.js', '.ts']
+   * };
+   * const codebase = new Codebase(opts);
+   * console.log(codebase.extensions);
+   * // Outputs: ['.js', '.ts']
+   */
   extensions: string[];
 
+  /**
+   * An array of file paths or patterns that the codebase should ignore during processing.
+   *
+   * The `ignoredFiles` property specifies files or file patterns that should be excluded from
+   * certain operations within the codebase, such as parsing, transformation, or dependency analysis.
+   * This can be useful for avoiding files that are not relevant to the project's source code, such as
+   * configuration files, test files, or documentation.
+   *
+   * Paths or patterns in this array can be absolute paths, relative paths, or even glob patterns.
+   *
+   * Some `\` are scaped because of JSDoc limitations
+   * @example
+   * const opts: CodebaseOpts = {
+   *   // ... other options
+   *   ignoredFiles: ['/path/to/config.js', '/path/to/config2.js']
+   * };
+   * const codebase = new Codebase(opts);
+   * console.log(codebase.ignoredFiles);
+   * // Outputs: ['/path/to/config.js']
+   *
+   */
   ignoredFiles: string[];
 
+  /**
+   * An array of import statements or patterns that the codebase should ignore during processing.
+   *
+   * The `ignoredImports` property specifies import statements or patterns that should be excluded or ignored
+   * during certain operations within the codebase, such as dependency analysis or transformation. This can
+   * be useful to avoid processing external libraries, mock data, or any other imports that are not essential
+   * for the project's main logic.
+   *
+   * The values in this array can be specific import names, modules, or even patterns that match multiple imports.
+   *
+   * @example
+   * const opts: CodebaseOpts = {
+   *   // ... other options
+   *   ignoredImports: ['mockData', 'externalLibrary']
+   * };
+   * const codebase = new Codebase(opts);
+   * console.log(codebase.ignoredImports);
+   * // Outputs: ['mockData', 'externalLibrary']
+   */
   ignoredImports: string[];
 
+  /**
+   * A collection of file instances managed by the codebase, indexed by their relative pathnames.
+   *
+   * The `files` property is an object where each key represents the relative pathname of a file
+   * within the codebase, and each value is an instance of `FileContainer` that encapsulates the file's
+   * details, contents, and operations.
+   *
+   * This structured representation allows for easy access, manipulation, and management of individual
+   * files within the codebase.
+   *
+   * @example
+   * const opts: CodebaseOpts = {
+   *   // ... other options
+   *   src: '/home/projects/project/',
+   *   files: [
+   *     ['/home/projects/project/path1.js', 'console.log("hello world")'],
+   *   ],
+   * };
+   * const codebase = new Codebase(opts);
+   * const fileInstance = codebase.files['/project/path1.js'];
+   * console.log(fileInstance);
+   * // Outputs: Instance of FileContainer for 'path1.js'
+   */
   files: FilesContainer;
 
+  /**
+   * The name of the root directory of the codebase.
+   *
+   * The `rootName` property provides the name of the root directory where the files of the codebase reside.
+   * It is extracted from the `src` property by taking the base name of the provided directory path.
+   *
+   * This property can be useful for referencing the root directory's name without the need for full path information,
+   * especially when working with operations that require relative pathnames or when displaying directory structures.
+   *
+   * @example
+   * const opts: CodebaseOpts = {
+   *   // ... other options
+   *   src: '/home/projects/project/'
+   * };
+   * const codebase = new Codebase(opts);
+   * console.log(codebase.rootName);
+   * // Outputs: 'project'
+   */
   rootName: string;
 
+  /**
+   * Provides the absolute path to the directory containing the root of the codebase, excluding the root directory itself.
+   *
+   * The `srcWithoutRoot` property provides the absolute path to the directory that contains the root of the codebase.
+   * It is derived by removing the base name (root name) of the `src` property. This can be useful when operations
+   * require references to directories just above the root or when setting up paths relative to the main project directory.
+   *
+   * @example
+   * const opts: CodebaseOpts = {
+   *   // ... other options
+   *   src: '/home/projects/project/'
+   * };
+   * const codebase = new Codebase(opts);
+   * console.log(codebase.srcWithoutRoot);
+   * // Outputs: '/home/projects'
+   */
   srcWithoutRoot: string;
 
+  /**
+   * Represents the contents of the package configuration for the codebase.
+   *
+   * The `package` property provides a structured representation of the package or configuration data associated
+   * with the codebase. This can include details like package name, version, dependencies, scripts, and more.
+   * It is typically derived from a package configuration file, such as a `package.json` in a Node.js project.
+   *
+   * As this property can store a variety of information specific to the project's setup and requirements,
+   * it is defined using the `PackageContents` type, which allows for flexible key-value pairs.
+   *
+   * @example
+   * const opts: CodebaseOpts = {
+   *   // ... other options
+   *   packageContents: {
+   *     name: 'my-project',
+   *     version: '1.0.0',
+   *     dependencies: {
+   *       'some-library': '^1.2.3'
+   *     }
+   *   }
+   * };
+   * const codebase = new Codebase(opts);
+   * console.log(codebase.package.name);
+   * // Outputs: 'my-project'
+   */
   package: PackageContents;
 
+  /**
+   * A list of dependencies associated with the codebase.
+   *
+   * The `dependencies` property contains an array of strings representing the dependencies of the codebase.
+   * These dependencies could be libraries, frameworks, or other modules that the codebase relies on for
+   * its functionality. The list can be populated based on the analysis of import or require statements
+   * in the codebase files or derived from other configuration data.
+   *
+   * This property is especially useful for understanding the external components the codebase interacts with,
+   * aiding in tasks such as dependency management, bundling, or tree-shaking.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * codebase.storeDependencies(); // Assuming this method populates the `dependencies` property
+   * console.log(codebase.dependencies);
+   * // Outputs: ['lodash', 'express', 'react']
+   */
   dependencies: string[];
 
+  /**
+   * Configuration options used to initialize and manage the codebase.
+   *
+   * The `opts` property contains various settings and parameters that influence the behavior, structure,
+   * and capabilities of the `Codebase` instance. These settings include:
+   *
+   * - `pipeline`: An optional array of functions representing a sequence of transformations or operations.
+   * - `src`: The source directory for the codebase.
+   * - `extensions`: An array of file extensions considered by the codebase.
+   * - `ignoredFiles`: An array of file paths or patterns that the codebase should ignore.
+   * - `packageContents`: An optional object representing the contents of the project's package (e.g., package.json).
+   * - `packagePath`: An optional path to the project's package file.
+   * - `ignoredImports`: An array of import statements or patterns that the codebase should ignore.
+   * - `custom`: Any additional custom configuration that doesn't fit into the above categories.
+   * - `files`: An array of file configurations, where each configuration is a tuple with the file's path and its content.
+   *
+   * These options provide the necessary context for the codebase to operate, enabling file parsing, dependency
+   * management, code transformations, and other essential tasks.
+   *
+   * @example
+   * const opts = {
+   *   src: '/path/to/project',
+   *   extensions: ['.js'],
+   *   ignoredFiles: ['config.js'],
+   *   files: [['/path/to/project/file1.js', 'console.log("hello world")']]
+   * };
+   * const codebase = new Codebase(opts);
+   * console.log(codebase.opts.src); // Outputs: '/path/to/project'
+   */
   opts: CodebaseOpts;
 
+  /**
+   * The constructor initializes properties like `src`, `extensions`, `ignoredFiles`, `ignoredImports`, and others
+   * using the values from the provided options. It also sets up the codebase's files, root directory name,
+   * dependencies, and package contents.
+   *
+   * @param opts - Configuration options for setting up the codebase.
+   * It includes properties like:
+   *   - `pipeline`: An optional array of functions representing a sequence of transformations or operations.
+   *   - `src`: The source directory for the codebase.
+   *   - `extensions`: An array of file extensions considered by the codebase.
+   *   - `ignoredFiles`: An array of file paths or patterns that the codebase should ignore.
+   *   - `packageContents`: An optional object representing the contents of the project's package (e.g., package.json).
+   *   - `packagePath`: An optional path to the project's package file.
+   *   - `ignoredImports`: An array of import statements or patterns that the codebase should ignore.
+   *   - `custom`: Any additional custom configuration that doesn't fit into the above categories.
+   *   - `files`: An array of file configurations, where each configuration is a tuple with the file's path and its content.
+   *
+   * @example
+   * const opts = {
+   *   src: '/path/to/project',
+   *   extensions: ['.js'],
+   *   ignoredFiles: ['config.js'],
+   *   files: [['/path/to/project/file1.js', 'console.log("hello world")']]
+   * };
+   * const codebase = new Codebase(opts);
+   */
   constructor(opts: CodebaseOpts) {
     this.src = opts.src;
     this.extensions = opts.extensions;
@@ -47,79 +274,344 @@ export class Codebase {
     this.storeDependencies();
   }
 
+  /**
+   * Returns the relative path of a file within the codebase.
+   *
+   * This method is useful for converting absolute paths to relative paths within the context of the codebase. It takes a file path as input
+   * and removes the portion of the path that matches the root directory, leaving only the relative path.
+   *
+   * @param path - The absolute path of the file or directory within the file system.
+   * @returns The relative path of the file or directory with respect to the root of the codebase.
+   *
+   * @example
+   * const opts: CodebaseOpts = {
+   *   // ... other options
+   *   src: '/home/projects/project/'
+   * };
+   * const codebase = new Codebase(opts);
+   * console.log(codebase.replaceRoot('/home/projects/project/path1/file1.js'));
+   * // Outputs: '/path1/file1.js'
+   */
   replaceRoot(path: string) {
     return path.replace(this.srcWithoutRoot, '');
   }
 
+  /**
+   * Processes and stores an array of file configurations into the codebase's `files` property.
+   *
+   * Each file configuration is an array consisting of the file's path and its content. This method
+   * processes each configuration by creating a new `FileContainer` instance for it and then storing
+   * this instance in the `files` property, indexed by the file's relative pathname.
+   *
+   * @param files - An array of file configurations where each configuration is a tuple with the
+   * file's path and its content.
+   * @returns An object representing the stored files, indexed by their relative pathnames.
+   *
+   * @example
+   * const opts: CodebaseOpts = {
+   *   // ... other options
+   *   src: '/home/projects/project/',
+   *   files: [
+   *     ['/home/projects/project/path1.js', 'console.log("hello world")'],
+   *     ['/home/projects/project/path2.js', 'console.log("goodbye world")']
+   *   ]
+   * };
+   * const codebase = new Codebase(opts);
+   * const storedFiles = codebase.storeFiles(opts.files);
+   * console.log(storedFiles['/path1.js']);
+   * // Outputs: Instance of FileContainer for 'path1.js'
+   */
   storeFiles(files: [string, string][]) {
     this.files = {};
     files.map((record: [string, string]) => this.storeFile(record));
     return this.files;
   }
 
+  /**
+   * Extracts and returns all the `FileContainer` instances managed by the codebase.
+   *
+   * The `extractFiles` method provides a way to retrieve all the file instances that are currently
+   * managed within the codebase's `files` property. Each `FileContainer` instance encapsulates
+   * information and operations related to a specific file within the codebase.
+   *
+   * @returns An array of `FileContainer` instances representing all the files managed by the codebase.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const allFiles = codebase.extractFiles();
+   * console.log(allFiles[0]);
+   * // Outputs the `FileContainer` instance for the first file.
+   */
   extractFiles(): FileContainerType[] {
     return Object.values(this.files);
   }
 
+  /**
+   * Creates and returns a new `FileContainer` instance for the provided file path and code.
+   *
+   * The `newFile` method offers a convenient way to create a new instance of the `FileContainer` class
+   * representing a file within the codebase. This instance contains information and operations related
+   * to the specified file, and it's associated with the current `Codebase` instance.
+   *
+   * @param path - The absolute path of the file within the file system.
+   * @param code - The content of the file represented as a string.
+   * @returns A new instance of the `FileContainer` class representing the specified file.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const filePath = '/home/projects/project/newFile.js';
+   * const fileCode = 'console.log("This is a new file.")';
+   * const newFileInstance = codebase.newFile(filePath, fileCode);
+   * console.log(newFileInstance.code);
+   * // Outputs: 'console.log("This is a new file.")'
+   */
   newFile(path: string, code: string): FileContainer {
     return new FileContainer(path, code, this);
   }
 
+  /**
+   * Processes a file configuration and stores it in the codebase's `files` property.
+   *
+   * The `storeFile` method takes a file configuration, represented as a tuple of the file's `path` and its `code` (content).
+   * It then creates a new `FileContainer` instance for this file and adds it to the `files` property,
+   * indexed by the file's relative pathname.
+   *
+   * @param record - A tuple containing the absolute path of the file and its content as a string.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const fileConfig = ['/home/projects/project/path3.js', 'console.log("Another file.")'];
+   * codebase.storeFile(fileConfig);
+   * console.log(codebase.files['/project/path3.js'].code);
+   * // Outputs: 'console.log("Another file.")'
+   */
   storeFile(record: [string, string]) {
     const [path, code] = record;
     const file = this.newFile(path, code);
     this.files[file.pathname] = file;
   }
 
+  /**
+   * Removes a file from the codebase's `files` property.
+   *
+   * The `removeFile` method provides a way to remove a specific file from the managed collection of files
+   * within the codebase.
+   *
+   * @param path - The relative path of the file to be removed, as it appears within the codebase's `files` property.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * codebase.removeFile('/project/path3.js');
+   * console.log(codebase.files['/project/path3.js']);
+   * // Outputs: undefined
+   */
   removeFile(path: string) {
     delete this.files[path];
   }
 
-  deepCopy(version: Codebase) {
+  /**
+   * Merges the properties from the given codebase to the current codebase instance.
+   *
+   * @param version - The Codebase to copy of files.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const codebase2 = new Codebase(opts);
+   * codebase.copy(codebase2);
+   * console.log(codebase.files === codebase2.files);
+   * // Outputs: true
+   */
+  copy(codebase: Codebase) {
     this.files = {};
-    copy(this.files, version.files);
+    copy(this, codebase);
   }
 
+  /**
+   * Retrieves the keys used to extract dependencies from the codebase's package property.
+   *
+   * This method provides the necessary keys that represent different categories of dependencies
+   * in the codebase's package property, such as 'dependencies', 'devDependencies', etc.
+   *
+   * @returns An array of strings representing the keys under which dependencies are stored in the codebase's package property.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const depKeys = codebase.dependencyKeys();
+   * console.log(depKeys);
+   * // Might output: ['dependencies', 'devDependencies', 'peerDependencies']
+   */
   dependencyKeys(): string[] {
     return [];
   }
 
+  /**
+   * Retrieves and stores the dependencies of the codebase based.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * codebase.storeDependencies();
+   * console.log(codebase.dependencies);
+   * // Outputs: ['lodash', 'express', ...]
+   */
   storeDependencies() {
     this.dependencies = storeDependencies(this, this.dependencyKeys());
   }
 
+  /**
+   * Restructures a given file within the codebase to follow the directory pattern.
+   *
+   * If the file isn't named "index", this method will move it into a new directory named after the file  and rename it to "index" inside that directory. Files already named "index" remain unchanged.
+   *
+   * @param file - The `FileContainer` instance to be organized. It should belong to this codebase instance.
+   * @returns The updated path of the file.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const fileInstance = codebase.files['/project/path1.js'];
+   * const newPath = codebase.makeDirectory(fileInstance);
+   * console.log(newPath);
+   * // Outputs: '/project/path1/index.js'
+   */
   makeDirectory(file: FileContainer) {
     return makeDirectory(this, file);
   }
 
+  /**
+   * Adds a `FileContainer` instance to the codebase's managed `files` property.
+   *
+   * This method provides a way to add a new file instance to the collection of files managed
+   * by the codebase. The file is indexed by its relative pathname within the `files` property.
+   *
+   * @param file - The `FileContainer` instance representing the file to be added to the codebase.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const fileInstance = new FileContainer('/home/projects/project/newFile.js', 'console.log("New file content.")', codebase);
+   * codebase.addFile(fileInstance);
+   * console.log(codebase.files['/project/newFile.js'].code);
+   * // Outputs: 'console.log("New file content.")'
+   */
   addFile(file: FileContainer) {
     this.files[file.pathname] = file;
   }
 
+  /**
+   * Updates the codebase's `files` property with the given array of `FileContainer` instances.
+   *
+   * This method iterates over the provided array of `FileContainer` instances and adds each of them
+   * to the codebase's managed `files` property. If a file with the same pathname already exists in the
+   * `files` property, it is replaced by the new `FileContainer` instance. This allows for batch updating
+   * or adding of files to the codebase.
+   *
+   * @param files - An array of `FileContainer` instances representing the files to be added or updated in the codebase.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const newFileInstances = [
+   *   new FileContainer('/project/file1.js', 'const hi = "hello";', codebase),
+   *   new FileContainer('/project/file2.js', '', codebase)
+   * ];
+   * codebase.updateFiles(newFileInstances);
+   * console.log(codebase.files['/project/file1.js'].code);
+   * // Outputs: 'const hi = "hello";'
+   */
   updateFiles(files: FileContainer[]) {
     files.forEach(this.addFile.bind(this));
   }
 
+  /**
+   * Saves the given code content to a file in the file system at the specified path.
+   *
+   * @param pathname - The absolute path where the file should be saved.
+   * @param code - The content of the file to be saved as a string.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const filePath = '/home/projects/project/savedFile.js';
+   * const fileCode = 'console.log("Saved file content.")';
+   * await codebase.saveFile(filePath, fileCode);
+   * // This will save the file at '/home/projects/project/savedFile.js' with the given content.
+   */
   saveFile(pathname: string, code: string) {
-    saveFile(pathname, code);
+    return saveFile(pathname, code);
   }
 
+  /**
+   * Saves the given data object to a file in the file system in JSON format at the specified path.
+   *
+   * @param pathname - The absolute path where the JSON file should be saved.
+   * @param data - The data object to be serialized and saved as a JSON file.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const jsonFilePath = '/home/projects/project/config.json';
+   * const jsonData = { project: "Sample", version: "1.0.0" };
+   * await codebase.saveToJSON(jsonFilePath, jsonData);
+   * // This will save the data object as a JSON string to a file named 'config.json' at '/home/projects/project'
+   */
   saveToJSON(pathname: string, data: RandomObject) {
-    saveToJSON(pathname, data);
+    return saveToJSON(pathname, data);
   }
 
+  /**
+   * Loads a hash object into the Codebase instance, shallow copying the data by keys and values.
+   *
+   *
+   * @param data - The data object to be assigned to the instance by key value.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const data = { project: "Sample", version: "1.0.0" };
+   * await codebase.fromJson(data);
+   * console.log(codebase.project == "Sample");
+   * // Outputs: true;
+   */
   fromJson(data: RandomObject) {
-    fromJson(data);
+    fromJson(data, this);
   }
 
+  /**
+   * Loads a JSON data from a file as a hash object and assigns the hash object to the codebase.
+   *
+   * @param path - The pathname of the file to read.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * const path = '/path/to/json/file.json';
+   * // the JSON in the file is { project: "Sample", version: "1.0.0" };
+   * await codebase.fromFile(path);
+   * console.log(codebase.project == "Sample");
+   * // Outputs: true;
+   */
   fromFile(path: string) {
     fromFile(path, this);
   }
 
+  /**
+   * Saves the content of all files in the codebase instance to the file system.
+   * Each file is saved at the location specified by the `pathname` property of the respective `FileContainer` instance.
+   * If the directory for the pathname doesn't exist, it is created.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * await codebase.toFiles();
+   * // It will save all the files in the codebase instance to their respective paths on the file system.
+   */
   toFiles() {
-    this.extractFiles().map(toFile);
+    const files = this.extractFiles();
+    return Promise.all(files.map((file) => file.save()));
   }
 
+  /**
+   * Iterates over all extracted files from the `Codebase` instance and saves each one to the file system.
+   * Each file is saved at its specified `pathname` with its associated content.
+   *
+   * @example
+   * const codebase = new Codebase(opts);
+   * // Assuming some files have been added or modified in the codebase
+   * codebase.save();
+   * // This will save all the extracted files to their respective paths on the file system.
+   */
   save() {
     this.extractFiles().map((file: FileContainerType) => file.save());
   }

--- a/packages/workspace/src/workspace/codebase/make-directory/index.ts
+++ b/packages/workspace/src/workspace/codebase/make-directory/index.ts
@@ -3,6 +3,25 @@ import { basename, dirname, join } from 'path';
 import type { Codebase } from '..';
 import type { FileContainer } from '../file';
 
+/**
+ * Restructures a given file in the codebase.
+ *
+ * If the file name is not "index", this function:
+ * 1. Creates a new directory with the base name of the file.
+ * 2. Renames the file to "index" with its original extension inside this new directory.
+ * If the file name is "index", the path remains unchanged.
+ *
+ * @param codebase - The codebase where file changes are applied. This object is also mutated in-place.
+ * @param file - The file to be restructured.
+ * @returns The new path of the file as a string.
+ *
+ * @example
+ * // Consider a file at './path1.ts'
+ * const codebase = new Codebase(...opts, { files: ['./path1.ts'] });
+ * const file = new FileContainer('./path1.ts', '', anotherCodebase);
+ * makeDirectory(codebase, file);
+ * // Now, file.pathname will be './path1/index.ts'
+ */
 export const makeDirectory = (codebase: Codebase, file: FileContainer) => {
   const filename = basename(file.pathname);
 

--- a/packages/workspace/src/workspace/codebase/save/index.ts
+++ b/packages/workspace/src/workspace/codebase/save/index.ts
@@ -1,45 +1,104 @@
-import fs from 'fs';
+import { readFile } from 'fs';
+import { mkdir, writeFile } from 'fs/promises';
 import { dirname } from 'path';
 
 import type { Codebase } from '..';
 import type { RandomObject } from '../../../types';
 import type { FileContainer } from '../file';
 
-const createFile = (pathname: string, contents: string) => {
-  fs.createWriteStream(pathname).write(contents);
-};
-
-const createDir = (pathname: string, contents: string) => {
+/**
+ * Creates a directory on the file system for the provided pathname and writes the contents to a file within that directory.
+ * If the directory doesn't exist, it will be created. After creating the directory,
+ * the contents are written to a file at the specified pathname.
+ *
+ * @param pathname - The path where the file should be created, including the file name.
+ * @param contents - The contents to be written to the file.
+ * @example
+ * // Assuming the directory '/path/to' doesn't exist
+ * await createDir('/path/to/file.txt', 'Hello, World!');
+ * // This will create a directory '/path/to' and a file 'file.txt' with the contents 'Hello, World!'
+ */
+export const createDir = async (pathname: string, contents: string) => {
   const folder = dirname(pathname);
-  fs.mkdir(folder, { recursive: true }, (err) => {
-    if (err) {
-      console.error(err);
-      return;
-    }
-    createFile(pathname, contents);
-  });
+  try {
+    await mkdir(folder, { recursive: true });
+    await writeFile(pathname, contents);
+  } catch (err) {
+    console.error(err);
+  }
 };
 
+// TODO: do we need this?
+/**
+ * Converts a given object into its JSON string representation.
+ *
+ * @param data - The object to be converted to a JSON string.
+ * @returns The JSON string representation of the provided data.
+ *
+ * @example
+ * const data = { key: 'value', array: [1, 2, 3] };
+ * const jsonString = objectToJsonString(data);
+ * console.log(jsonString); // Outputs: '{"key":"value","array":[1,2,3]}'
+ */
 export const toJson = (data: RandomObject) => {
   return JSON.stringify(data);
 };
 
+/**
+ * Saves the provided code to a file on the file system at the specified pathname.
+ * If the directory for the pathname doesn't exist, it will be created.
+ *
+ * @param pathname - The path where the file should be saved, including the file name.
+ * @param code - The code or content to be saved to the file.
+ *
+ * @example
+ * await saveFile('/path/to/file.txt', 'Hello, World!');
+ * // This will save the text 'Hello, World!' to a file named 'file.txt' at '/path/to'
+ */
 export const saveFile = (pathname: string, code: string) => {
-  createDir(pathname, code);
+  return createDir(pathname, code);
 };
 
-export const saveToJSON = (pathname: string, data: RandomObject) => {
-  createDir(pathname, toJson(data));
+// TODO: check if this is needed
+// TODO: maybe validate that the path contains a json file extension
+/**
+ * Saves the provided data as a JSON string to a file on the file system at the specified pathname.
+ * If the directory for the pathname doesn't exist, it will be created.
+ *
+ * @param pathname - The path where the JSON file should be saved, including the file name.
+ * @param data - The data object to be serialized and saved as JSON.
+ *
+ * @example
+ * const data = { key: 'value', array: [1, 2, 3] };
+ * await saveToJSON('/path/to/data.json', data);
+ * // This will save the object as a JSON string to a file named 'data.json' at '/path/to'
+ */
+export const saveToJSON = async (pathname: string, data: RandomObject) => {
+  await createDir(pathname, toJson(data));
 };
 
+/**
+ * Reads a JSON file from the file system at the provided pathname, parses its content,
+ * and updates the given `codebase` instance using the parsed data.
+ *
+ * @param pathname - The path to the file that should be read.
+ * @param codebase - The codebase object to be updated with the parsed data.
+ *
+ * @example
+ * const codebase = new Codebase();
+ * fromFile('/path/to/data.json', codebase);
+ * // If the file '/path/to/data.json' contains valid JSON,
+ * // the codebase object will be updated using that data.
+ */
 export const fromFile = (pathname: string, codebase: Codebase) => {
-  fs.readFile(pathname, { encoding: 'utf-8' }, function (err: NodeJS.ErrnoException | null, data: string) {
+  readFile(pathname, { encoding: 'utf-8' }, function (err: NodeJS.ErrnoException | null, data: string) {
     if (err) {
       console.error(err);
       return;
     }
     try {
       const jsonData: Record<string, unknown> = JSON.parse(data);
+      // TODO: should it run on the codebase instance or just using utility functions?
       codebase.fromJson(jsonData);
     } catch (parseError) {
       console.error('Could not parse data:', parseError);
@@ -47,14 +106,27 @@ export const fromFile = (pathname: string, codebase: Codebase) => {
   });
 };
 
-export const toFile = (file: FileContainer) => {
+/**
+ * Saves the content of a `FileContainer` instance to a file on the file system.
+ * The file will be saved at the location specified by the `pathname` property of the `FileContainer`.
+ * If the directory for the pathname doesn't exist, it will be created.
+ *
+ * @param file - The `FileContainer` instance containing the data to be saved.
+ * @example
+ * const fileContainer = new FileContainer('/path/to/file.js', 'console.log("Hello");', codebase);
+ * toFile(fileContainer);
+ * // This will save the content of `fileContainer` to a file named 'file.js' at '/path/to'
+ */
+export const toFile = async (file: FileContainer) => {
   const { pathname: path, code } = file;
-  createDir(path, code);
+  return createDir(path, code);
 };
 
-export const fromJson = (data: RandomObject) => {
+// TODO: add jsdocs
+// TODO: ensure implementation (used in a method of the Codebase class), I'm not sure about the desired behavior
+export const fromJson = (data: RandomObject, codebase: Codebase) => {
   Object.keys(data).forEach((key: string) => {
-    Object.defineProperty(this, key, {
+    Object.defineProperty(codebase, key, {
       value: data[key],
       writable: true,
       enumerable: true,

--- a/packages/workspace/src/workspace/codebase/save/index.ts
+++ b/packages/workspace/src/workspace/codebase/save/index.ts
@@ -28,7 +28,6 @@ export const createDir = async (pathname: string, contents: string) => {
   }
 };
 
-// TODO: do we need this?
 /**
  * Converts a given object into its JSON string representation.
  *
@@ -98,7 +97,6 @@ export const fromFile = (pathname: string, codebase: Codebase) => {
     }
     try {
       const jsonData: Record<string, unknown> = JSON.parse(data);
-      // TODO: should it run on the codebase instance or just using utility functions?
       codebase.fromJson(jsonData);
     } catch (parseError) {
       console.error('Could not parse data:', parseError);
@@ -123,7 +121,7 @@ export const toFile = async (file: FileContainer) => {
 };
 
 // TODO: add jsdocs
-// TODO: ensure implementation (used in a method of the Codebase class), I'm not sure about the desired behavior
+// TODO: ensure implementation
 export const fromJson = (data: RandomObject, codebase: Codebase) => {
   Object.keys(data).forEach((key: string) => {
     Object.defineProperty(codebase, key, {

--- a/packages/workspace/src/workspace/codebase/store-dependencies/index.ts
+++ b/packages/workspace/src/workspace/codebase/store-dependencies/index.ts
@@ -1,5 +1,23 @@
 import type { Codebase } from '..';
 
+/**
+ * Retrieves and stores the dependencies of a codebase based on the provided dependency keys.
+ *
+ * This function extracts dependencies from the codebase's `package` property based on the provided
+ * `dependencyKeys` and returns them as an array of strings. If a dependency key exists within the codebase's package, all its corresponding dependencies are added to the list.
+ *
+ * @param codebase - The instance of the `Codebase` class which contains details about the project codebase.
+ * @param dependencyKeys - An array of strings representing the keys under which dependencies are stored in the codebase's package property (e.g., ['dependencies', 'devDependencies']).
+ *
+ * @returns An array of strings representing the names of the dependencies found in the codebase's package based on the provided dependency keys.
+ *
+ * @example
+ * const codebase = new Codebase(opts);
+ * const keys = ['dependencies', 'devDependencies'];
+ * const dependencies = storeDependencies(codebase, keys);
+ * console.log(dependencies);
+ * // Outputs: ['lodash', 'express', ...]
+ */
 export const storeDependencies = (codebase: Codebase, dependencyKeys: string[]) => {
   const dependencies: Map<string, string> = new Map();
   dependencyKeys.forEach((key: string) => {

--- a/packages/workspace/src/workspace/index.ts
+++ b/packages/workspace/src/workspace/index.ts
@@ -5,19 +5,85 @@ import type { WorkspaceOpts } from '../types';
 import type { FileContainer } from './codebase/file';
 
 export class Workspace {
+  /**
+   * Configuration options for the Workspace instance. It dictates how the workspace
+   * should operate and what kind of files or actions it should consider or ignore.
+   * For instance, it can define the source directory, file extensions to consider,
+   * files to ignore, pipeline functions to apply, and other custom configurations.
+   *
+   * @example
+   * {
+   *   src: './src',
+   *   extensions: ['.js', '.ts'],
+   *   ignoredFiles: ['ignoreMe.js'],
+   *   packagePath: './package.json',
+   *   ignoredImports: ['specific-import'],
+   *   custom: { customConfig: true }
+   * }
+   *  */
   opts: WorkspaceOpts;
 
+  /**
+   * By default, if no files are provided in the options,
+   * the constructor will use the `defaultLoader` method
+   * to populate the `files` based on the provided directory options.
+   *
+   * @param opts - Configuration options for the Workspace instance.
+   *
+   * @example
+   * const workspace = new Workspace({
+   *   src: './src',
+   *   extensions: ['.js', '.ts'],
+   *   ignoredFiles: ['ignoreMe.js'],
+   *   packagePath: './package.json',
+   *   ignoredImports: ['specific-import'],
+   *   custom: { customConfig: true }
+   * });
+   */
   constructor(opts: WorkspaceOpts) {
     this.defaultLoader(opts);
     this.opts = opts;
   }
 
+  /**
+   * Loads files from a specified directory if the `files` option is not provided.
+   *
+   * @param opts - Configuration options for loading files into the Workspace.
+   *
+   * @example
+   * const workspace = new Workspace({ src: './src' });
+   * // Assuming there are no files specified in opts,
+   * // the defaultLoader would be triggered to populate them based on the 'src' directory.
+   */
   defaultLoader(opts: WorkspaceOpts) {
     if (!opts.files) {
       opts.files = readDirectory(opts);
     }
   }
 
+  /**
+   * Processes files through a series of functions, forming a pipeline. The pipeline method
+   * offers a structured approach to sequentially process each file using a chain of functions,
+   * supporting both synchronous and asynchronous operations. Each function in the pipeline has
+   * access to shared data or configuration options, allowing for flexible file processing within
+   * the context of a workspace.
+   *
+   * @param files - Array of file containers to be processed.
+   * @param pipeline - An array of functions that each file should be processed through.
+   * @param opts - Configuration options for processing.
+   * @returns Promise resulting from the pipeline execution.
+   *
+   * @example
+   * const workspace = new Workspace({ src: './src' });
+   * const myPipeline = [
+   *   (file, state, opts, workspace) => { console.log(file.name); }
+   * ];
+   *
+   * const filesToProcess = [...]; // Assume an array of FileContainer objects.
+   * workspace.pipeline(filesToProcess, myPipeline, workspace.opts);
+   * // This would log the name of each file in the filesToProcess array.
+   *
+   */
   async pipeline(files: FileContainer[], pipeline: Function[] | undefined, opts: WorkspaceOpts) {
     return runPipeline(files, pipeline, opts, this);
   }

--- a/packages/workspace/src/workspace/pipeline/index.ts
+++ b/packages/workspace/src/workspace/pipeline/index.ts
@@ -1,6 +1,20 @@
 import type { State, WorkspaceOpts, WorkspaceType } from '../../types';
 import type { FileContainer } from '../codebase/file';
 
+// TODO: add examples to the jsdoc comments
+
+/**
+ * Wraps a provided asynchronous function in a promise, ensuring that the function's
+ * execution can be awaited. If the function throws an error during its execution,
+ * the error is passed to the promise's rejection handler.
+ *
+ * @param func The function to execute asynchronously.
+ * @param file The file container being processed.
+ * @param state The current state during processing.
+ * @param opts The options provided for the workspace.
+ * @param workspace The current workspace context.
+ * @returns A promise that resolves with the result of the function or rejects with an error.
+ */
 function wait(func: Function, file: FileContainer, state: State, opts: WorkspaceOpts, workspace: WorkspaceType) {
   return new Promise(async (resolve, reject) => {
     try {
@@ -12,6 +26,17 @@ function wait(func: Function, file: FileContainer, state: State, opts: Workspace
   });
 }
 
+/**
+ * Executes the provided asynchronous function concurrently for each file in the list.
+ * It waits for all invocations to complete and returns their combined results.
+ *
+ * @param func The function to execute asynchronously on each file.
+ * @param files Array of file containers to be processed.
+ * @param state The current state during processing.
+ * @param opts The options provided for the workspace.
+ * @param workspace The current workspace context.
+ * @returns A promise that resolves with an array of results from each function invocation.
+ */
 const invoke = async (
   func: Function,
   files: FileContainer[],
@@ -23,6 +48,18 @@ const invoke = async (
   return Promise.all(promises);
 };
 
+/**
+ * Sequentially processes each function in the pipeline for all the provided files.
+ * This function iterates over each function in the pipeline and invokes it on the
+ * provided files, accumulating results into the state object. The pipeline processing
+ * completes when all functions have been invoked for all files.
+ *
+ * @param files Array of file containers to be processed.
+ * @param pipeline Array of functions that form the processing pipeline.
+ * @param opts The options provided for the workspace.
+ * @param workspace The current workspace context.
+ * @param resolve Callback function to signal the completion of processing.
+ */
 const promise = async (
   files: FileContainer[],
   pipeline: Function[],
@@ -41,6 +78,19 @@ const promise = async (
   resolve();
 };
 
+/**
+ * Initiates the processing of a given set of files through a defined pipeline of functions.
+ * If the pipeline functions are not provided, the function returns false immediately.
+ * Otherwise, it processes the files through the pipeline, ensuring all pipeline functions
+ * are executed for each file. The function returns a promise which resolves once all the
+ * pipeline functions have been executed for all the files.
+ *
+ * @param files Array of file containers to be processed.
+ * @param pipelineFunctions Array of functions that form the processing pipeline. If undefined, the function returns false.
+ * @param opts Configuration options for the workspace.
+ * @param workspace The current workspace context in which the files are being processed.
+ * @returns A promise that resolves once the files have been processed or false if pipelineFunctions is undefined.
+ */
 export const pipeline = async (
   files: FileContainer[],
   pipelineFunctions: Function[] | undefined,
@@ -49,7 +99,7 @@ export const pipeline = async (
 ) => {
   if (!pipelineFunctions) return false;
 
-  return new Promise((resolve) => {
-    promise(files, pipelineFunctions, opts, workspace, resolve);
+  return new Promise(async (resolve) => {
+    await promise(files, pipelineFunctions, opts, workspace, resolve);
   });
 };


### PR DESCRIPTION
This PR introduces JSDoc-style documentation for each function, method, and property. This enhances maintainability and readability, providing clear insight into what each function does, its parameters, and expected return values. We could also use this to automatically generate documentation later on.