### PR TITLE
[workspace-node]: Use named exports

### DIFF
--- a/.changeset/shy-seals-relate.md
+++ b/.changeset/shy-seals-relate.md
@@ -1,0 +1,5 @@
+---
+'@modular-rocks/workspace-node': patch
+---
+
+Use named exports

--- a/packages/workspace-node/src/index.ts
+++ b/packages/workspace-node/src/index.ts
@@ -1,6 +1,5 @@
-import Workspace from './workspace';
-import FileContainer from './workspace/codebase/file';
-import Codebase from './workspace/codebase';
+import { Workspace } from './workspace';
+import { Codebase } from './workspace/codebase';
+import { FileContainer } from './workspace/codebase/file';
 
-export { Workspace, FileContainer, Codebase };
-export default Workspace;
+export { Codebase, FileContainer, Workspace };

--- a/packages/workspace-node/src/workspace/codebase/file/index.test.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/index.test.ts
@@ -1,8 +1,8 @@
 import { identifier, importDeclaration, importDefaultSpecifier, stringLiteral } from '@babel/types';
 
-import Codebase from '..';
+import { Codebase } from '..';
 
-import { CodebaseOpts } from '../../../types';
+import type { CodebaseOpts } from '../../../types';
 
 const str = JSON.stringify;
 

--- a/packages/workspace-node/src/workspace/codebase/file/index.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/index.ts
@@ -1,14 +1,14 @@
-import t from '@babel/types';
 import { FileContainer as FileContainerBase } from '@modular-rocks/workspace';
 
-import Codebase from '..';
+import type { File, Statement } from '@babel/types';
 
-import parse from './parse';
-import print from './print';
-import tooSimple from './too-simple';
+import { Codebase } from '..';
+import { parse } from './parse';
+import { print } from './print';
+import { tooSimple } from './too-simple';
 
-export default class FileContainer extends FileContainerBase {
-  ast?: t.File;
+export class FileContainer extends FileContainerBase {
+  ast?: File;
 
   constructor(path: string, code: string, codebase: Codebase) {
     super(path, code, codebase);
@@ -26,7 +26,7 @@ export default class FileContainer extends FileContainerBase {
     return print(ast, {}).code;
   }
 
-  addImport(importStatement: t.Statement) {
+  addImport(importStatement: Statement) {
     if (!this.ast || !this.ast.program.body) return false;
     this.ast.program.body.unshift(importStatement);
     return false;

--- a/packages/workspace-node/src/workspace/codebase/file/parse/index.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/parse/index.ts
@@ -1,11 +1,12 @@
-import { parse } from '@babel/parser';
+import { parse as babelParser } from '@babel/parser';
 
 import { RandomObject } from '../../../../types';
 
+// TODO: check type
 const babelConfig: RandomObject = {
   sourceType: 'module',
   createParenthesizedExpressions: true,
   plugins: ['jsx', ['typescript', { isTSX: true }], 'babel-plugin-recast'],
 };
 
-export default (code: string) => parse(code, babelConfig);
+export const parse = (code: string) => babelParser(code, babelConfig);

--- a/packages/workspace-node/src/workspace/codebase/file/print/index.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/print/index.ts
@@ -1,4 +1,4 @@
-import { print } from 'recast';
 import type { Options, types } from 'recast';
+import { print as recastPrinter } from 'recast';
 
-export default (ast: types.ASTNode, opts?: Options) => print(ast, opts);
+export const print = (ast: types.ASTNode, opts?: Options) => recastPrinter(ast, opts);

--- a/packages/workspace-node/src/workspace/codebase/file/too-simple/index.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/too-simple/index.ts
@@ -1,9 +1,9 @@
-import t from '@babel/types';
-import { maintainability, loc, totalCyclomaticComplexity } from '@modular-rocks/metrics-ts-js';
+import { File } from '@babel/types';
+import { loc, maintainability, totalCyclomaticComplexity } from '@modular-rocks/metrics-ts-js';
 
 interface MetricOpts {
   code?: string;
-  ast?: t.File;
+  ast?: File;
   minLoc?: number;
   minMaintainability?: number;
 }
@@ -31,7 +31,7 @@ export const measure = (opts: Opts) => {
   return scores;
 };
 
-export default (metricOpts: MetricOpts) => {
+export const tooSimple = (metricOpts: MetricOpts) => {
   const scores = measure({ loc: true, maintainability: true, metricOpts });
   const minLoc = metricOpts.minLoc || 50;
   const minMaintainability = metricOpts.minMaintainability || 95;

--- a/packages/workspace-node/src/workspace/codebase/index.test.ts
+++ b/packages/workspace-node/src/workspace/codebase/index.test.ts
@@ -1,4 +1,4 @@
-import Codebase from '.';
+import { Codebase } from '.';
 
 import { CodebaseOpts } from '../../types';
 

--- a/packages/workspace-node/src/workspace/codebase/index.ts
+++ b/packages/workspace-node/src/workspace/codebase/index.ts
@@ -1,10 +1,10 @@
 import { Codebase as CodebaseBase } from '@modular-rocks/workspace';
 
-import FileContainer from './file';
+import { FileContainer } from './file';
 
-import { CodebaseOpts } from '../../types';
+import type { CodebaseOpts } from '../../types';
 
-export default class Codebase extends CodebaseBase {
+export class Codebase extends CodebaseBase {
   constructor(opts: CodebaseOpts) {
     super(opts);
   }

--- a/packages/workspace-node/src/workspace/index.test.ts
+++ b/packages/workspace-node/src/workspace/index.test.ts
@@ -1,5 +1,5 @@
-import Workspace from '.';
-import Codebase from './codebase';
+import { Workspace } from '.';
+import { Codebase } from './codebase';
 
 import type { CodebaseOpts, WorkspaceOpts } from '../types';
 

--- a/packages/workspace-node/src/workspace/index.ts
+++ b/packages/workspace-node/src/workspace/index.ts
@@ -3,7 +3,7 @@ import { Workspace as WorkspaceBase } from '@modular-rocks/workspace';
 
 import type { WorkspaceOpts } from '../types';
 
-export default class Workspace extends WorkspaceBase {
+export class Workspace extends WorkspaceBase {
   constructor(opts: WorkspaceOpts) {
     super(opts);
   }


### PR DESCRIPTION
Continuing the migration started in #29 for the `workspace-node` package.