### PR TITLE
[workspace-node]: Preserve end of lines

### DIFF
--- a/.changeset/ninety-dolls-leave.md
+++ b/.changeset/ninety-dolls-leave.md
@@ -1,0 +1,5 @@
+---
+'@modular-rocks/workspace-node': patch
+---
+
+fix: Preserve end of lines

--- a/packages/workspace-node/src/workspace/codebase/file/index.test.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/index.test.ts
@@ -2,6 +2,7 @@ import { identifier, importDeclaration, importDefaultSpecifier, stringLiteral } 
 
 import { Codebase } from '..';
 
+import { FileContainer } from '.';
 import type { CodebaseOpts } from '../../../types';
 
 const str = JSON.stringify;
@@ -43,4 +44,64 @@ describe('FileContainer', () => {
 
     expect(file.print()).toBe('import myModule from "my-module";\nexport default x => x * x;');
   }, 7000);
+});
+
+describe('FileContainer - getDominantEOL', () => {
+  const opts: CodebaseOpts = {
+    pipeline: [],
+    files: [],
+    src: '/home/projects/project/',
+    extensions: [],
+    ignoredFiles: [],
+    ignoredImports: [],
+    packageContents: {},
+  };
+
+  test('Should identify Windows (CRLF) EOL', () => {
+    const filePath = `/home/projects/project/file.js`;
+    const code = "'Hello\r\nWorld\r\n'";
+    const codebase = new Codebase(opts);
+    const fileContainer = new FileContainer(filePath, code, codebase);
+    expect(fileContainer.getDominantEOL()).toBe('\r\n');
+  });
+
+  test('Should identify Unix (LF) EOL', () => {
+    const filePath = `/home/projects/project/file.js`;
+    const code = "'Hello\nWorld\n'";
+    const codebase = new Codebase(opts);
+    const fileContainer = new FileContainer(filePath, code, codebase);
+    expect(fileContainer.getDominantEOL()).toBe('\n');
+  });
+
+  test('Should identify old Mac (CR) EOL', () => {
+    const filePath = `/home/projects/project/file.js`;
+    const code = "'Hello\rWorld\r'";
+    const codebase = new Codebase(opts);
+    const fileContainer = new FileContainer(filePath, code, codebase);
+    expect(fileContainer.getDominantEOL()).toBe('\r');
+  });
+
+  test('Should default to LF for mixed EOLs with a tie', () => {
+    const filePath = `/home/projects/project/file.js`;
+    const code = "'Hello\r\nWorld\n'";
+    const codebase = new Codebase(opts);
+    const fileContainer = new FileContainer(filePath, code, codebase);
+    expect(fileContainer.getDominantEOL()).toBe('\n');
+  });
+
+  test('Should default to given EOL for mixed EOLs with a tie', () => {
+    const filePath = `/home/projects/project/file.js`;
+    const code = "'Hello\r\nWorld\r'";
+    const codebase = new Codebase(opts);
+    const fileContainer = new FileContainer(filePath, code, codebase);
+    expect(fileContainer.getDominantEOL('\r')).toBe('\r');
+  });
+
+  test('Should default to LF for no newlines', () => {
+    const filePath = `/home/projects/project/file.js`;
+    const code = "'HelloWorld'";
+    const codebase = new Codebase(opts);
+    const fileContainer = new FileContainer(filePath, code, codebase);
+    expect(fileContainer.getDominantEOL()).toBe('\n');
+  });
 });

--- a/packages/workspace-node/src/workspace/codebase/file/index.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/index.ts
@@ -7,6 +7,8 @@ import { parse } from './parse';
 import { print } from './print';
 import { tooSimple } from './too-simple';
 
+type EndOfLine = '\r\n' | '\n' | '\r';
+
 export class FileContainer extends FileContainerBase {
   ast?: File;
 
@@ -18,12 +20,52 @@ export class FileContainer extends FileContainerBase {
     return tooSimple({ ast: this.ast });
   }
 
+  /**
+   * Determines the dominant end-of-line (EOL) sequence in the given code.
+   *
+   * There are three primary EOL sequences across different operating systems:
+   * - \r\n (CRLF) - Mainly used on Windows
+   * - \n (LF) - Used on Unix-like systems, including Linux and macOS
+   * - \r (CR) - Mainly used on old Mac systems
+   *
+   * @param {EndOfLine} [defaultEOL='\n'] - The default EOL sequence to use in case of ties or absence of newlines.
+   *
+   * @returns The dominant EOL sequence. Defaults to \n if there's a tie or no newlines.
+   */
+  getDominantEOL(defaultEOL: EndOfLine = '\n') {
+    const { code } = this;
+
+    let crlfCount = 0;
+    let lfCount = 0;
+    let crCount = 0;
+
+    for (let i = 0; i < code.length; i += 1) {
+      if (code[i] === '\r') {
+        if (code[i + 1] === '\n') {
+          crlfCount += 1;
+          i += 1; // Skip the next character since we've already counted it.
+        } else {
+          crCount += 1;
+        }
+      } else if (code[i] === '\n') {
+        lfCount += 1;
+      }
+    }
+
+    if (crlfCount > lfCount && crlfCount > crCount) return '\r\n';
+    if (lfCount > crlfCount && lfCount > crCount) return '\n';
+    if (crCount > crlfCount && crCount > lfCount) return '\r';
+
+    // If there's a tie or no newlines, default to \n (or any preference you have)
+    return defaultEOL;
+  }
+
   codeToAST() {
     return parse(this.code);
   }
 
   astToCode(ast: any) {
-    return print(ast, {}).code;
+    return print(ast, { lineTerminator: this.getDominantEOL() }).code;
   }
 
   addImport(importStatement: Statement) {

--- a/packages/workspace-node/src/workspace/codebase/file/index.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/index.ts
@@ -21,7 +21,7 @@ export class FileContainer extends FileContainerBase {
   }
 
   /**
-   * Determines the dominant end-of-line (EOL) sequence in the given code.
+   * Determines the dominant end-of-line (EOL) sequence in the current code.
    *
    * There are three primary EOL sequences across different operating systems:
    * - \r\n (CRLF) - Mainly used on Windows


### PR DESCRIPTION
Now we will detect the predominant end-of-line (EOL) format in the code and preserve this EOL when generating code from an AST.

Progressing with issue #4.