### PR TITLE
[slimfast-node]: use posix paths for imports

### DIFF
--- a/.changeset/dry-fireants-stare.md
+++ b/.changeset/dry-fireants-stare.md
@@ -1,0 +1,5 @@
+---
+'@modular-rocks/slimfast-node': patch
+---
+
+fix: use posix paths for imports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: Run tests
         run: pnpm test
-        continue-on-error: ${{ matrix.os == 'windows-latest' }}
 
       - name: Linting
         run: pnpm lint

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/combine-imports/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/combine-imports/index.ts
@@ -1,4 +1,4 @@
-import { dirname, relative, resolve } from 'path';
+import { dirname, relative, resolve } from 'path/posix';
 
 import { Binding } from '@babel/traverse';
 import {

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/import-statement/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/import-statement/index.ts
@@ -1,5 +1,6 @@
-import { join, relative, dirname, basename } from 'path';
-import { importDeclaration, importDefaultSpecifier, identifier, stringLiteral } from '@babel/types';
+import { basename, dirname, join, relative } from 'path/posix';
+
+import { identifier, importDeclaration, importDefaultSpecifier, stringLiteral } from '@babel/types';
 
 export default (name: string, pathname: string, parentPath: string, path: RandomObject) => {
   name = path.isJSXElement() ? name.charAt(0).toUpperCase() + name.slice(1) : name;

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/index.ts
@@ -1,4 +1,4 @@
-import { dirname, extname, resolve } from 'path';
+import { dirname, extname, resolve } from 'path/posix';
 
 import { NodePath } from '@babel/traverse';
 import { program } from '@babel/types';


### PR DESCRIPTION
This PR normalizes the output of import paths in the `slimfast-node` package to use POSIX-style forward slashes.

Before (on windows)
```
import { foo } from 'path\\to\\lib';
```

After (on windows)
```
import { foo } from 'path/to/lib';
```

Closes #4 
