### PR TITLE
[CI]: Run build only once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: pnpm build
 
       - name: Run tests
-        run: pnpm test
+        run: pnpm test:only
 
       - name: Linting
         run: pnpm lint

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:w": "turbo run build:w",
     "build:prod": "turbo run build:prod",
     "test": "turbo run test",
+    "test:only": "turbo run test --only",
     "test:w": "turbo run test:w",
     "coverage": "turbo run coverage",
     "dev": "turbo run dev --parallel",


### PR DESCRIPTION
In the current setup, we execute the build process twice. With this change, the build will only run once. Following the build, tests will be executed without triggering another build.