### PR TITLE
[workspace]: Add tests for `copy` utility

### DIFF
--- a/packages/workspace/src/workspace/codebase/copy/index.test.ts
+++ b/packages/workspace/src/workspace/codebase/copy/index.test.ts
@@ -2,13 +2,31 @@ import { describe, expect, test } from 'vitest';
 
 import { copy } from '.';
 
-const str = JSON.stringify;
+describe('"copy" utility', () => {
+  test('Should copy properties to an empty object', async () => {
+    const localObject = {};
+    const foreignObject = { text: 'hello world' };
 
-describe('Copy', () => {
-  test('Everything works', async () => {
-    const object1 = { text: 'hello world' };
-    const object2 = {};
-    copy(object2, object1);
-    expect(str(object2)).toBe(str(object1));
+    copy(localObject, foreignObject);
+
+    expect(localObject).toEqual({ text: 'hello world' });
+  });
+
+  test('Should merge properties into an existing object', async () => {
+    const localObject = { text: 'hello world' };
+    const foreignObject = { sample: 'text' };
+
+    copy(localObject, foreignObject);
+
+    expect(localObject).toEqual({ text: 'hello world', sample: 'text' });
+  });
+
+  test('Should remain unchanged when adding an empty object', async () => {
+    const localObject = { sample: 'text' };
+    const foreignObject = {};
+
+    copy(localObject, foreignObject);
+
+    expect(localObject).toEqual({ sample: 'text' });
   });
 });


### PR DESCRIPTION
In this PR, additional tests have been added for the `copy` utility within the `workspace` package to ensure its functionality.