### PR TITLE
[workspace]: Fix pipeline promise error handling and add tests

### DIFF
--- a/.changeset/three-spiders-shave.md
+++ b/.changeset/three-spiders-shave.md
@@ -1,0 +1,5 @@
+---
+'@modular-rocks/workspace': patch
+---
+
+Fix: Correctly reject errors in the `pipeline` function's promise.

--- a/packages/workspace/src/workspace/pipeline/index.ts
+++ b/packages/workspace/src/workspace/pipeline/index.ts
@@ -78,8 +78,8 @@ const promise = async (
   const state: State = {};
 
   for (const func of pipeline) {
-    const isNotFunction = typeof func === 'function';
-    if (isNotFunction) {
+    const isFunction = typeof func === 'function';
+    if (isFunction) {
       await invoke(func, files, state, opts, workspace);
     }
   }
@@ -105,9 +105,13 @@ export const pipeline = async (
   opts: WorkspaceOpts,
   workspace: WorkspaceType
 ) => {
-  if (!pipelineFunctions) return false;
+  if (!pipelineFunctions || pipelineFunctions.length === 0) return false;
 
-  return new Promise(async (resolve) => {
-    await promise(files, pipelineFunctions, opts, workspace, resolve);
+  return new Promise(async (resolve, reject) => {
+    try {
+      await promise(files, pipelineFunctions, opts, workspace, resolve);
+    } catch (error) {
+      reject(error);
+    }
   });
 };


### PR DESCRIPTION
In this PR, the `pipeline` function utility in the `workspace` package has been updated to correctly reject errors in a promise. Additionally, tests have been added to ensure its functionality.
