### PR TITLE
[workspace-node]: Add tests for `FileContainer` and fix to the `addImport` method's return

### DIFF
--- a/.changeset/slimy-paws-sparkle.md
+++ b/.changeset/slimy-paws-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@modular-rocks/workspace-node': patch
+---
+
+Fix to the `addImport` method's return

--- a/packages/workspace-node/src/workspace/codebase/file/index.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/index.ts
@@ -71,6 +71,6 @@ export class FileContainer extends FileContainerBase {
   addImport(importStatement: Statement) {
     if (!this.ast || !this.ast.program.body) return false;
     this.ast.program.body.unshift(importStatement);
-    return false;
+    return true;
   }
 }


### PR DESCRIPTION
- Tests have been added for the `FileContainer`.
- A minor fix has been made to the `addImport` method's return.