### PR TITLE
[devcontainer]: Change Node image to v16

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
   "name": "Node.js & TypeScript",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-16-bullseye",
   "features": {
     "ghcr.io/devcontainers-contrib/features/pnpm:2": {}
   },


### PR DESCRIPTION
Changes the Node.js & TypeScript image version in `.devcontainer/devcontainer.json` to `1-16-bullseye` (Node v16) to align more closely with our minimum Node.js requirement.
