### PR TITLE
Update min Node version to 18 for all pkgs

### DIFF
--- a/.changeset/tough-forks-shake.md
+++ b/.changeset/tough-forks-shake.md
@@ -1,0 +1,9 @@
+---
+'@modular-rocks/traverse-files': patch
+'@modular-rocks/workspace-node': patch
+'@modular-rocks/slimfast-node': patch
+'@modular-rocks/workspace': patch
+'@modular-rocks/slimfast': patch
+---
+
+Internal: Updated the minimum required Node version to 18 for all packages, aligning with the LTS status of Node.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
   "name": "Node.js & TypeScript",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-16-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-18-bullseye",
   "features": {
     "ghcr.io/devcontainers-contrib/features/pnpm:2": {}
   },

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           version: 8
 
-      - name: Setup Node.js 16
+      - name: Setup Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: pnpm
 
       - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [16]
+        node-version: [18]
 
     steps:
       - name: Checkout repository

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Slimfast super-repo",
   "private": true,
   "engines": {
-    "node": ">=16.x"
+    "node": ">=18.x"
   },
   "scripts": {
     "build": "turbo run build",

--- a/packages/slimfast-node/package.json
+++ b/packages/slimfast-node/package.json
@@ -12,7 +12,7 @@
   },
   "types": "./dist/declarations.d.ts",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "dist"

--- a/packages/slimfast-node/tsconfig.json
+++ b/packages/slimfast-node/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["src"],
   "extends": "tsconfig/tsconfig.json",
   "compilerOptions": {
-    "target": "es2016",
+    "target": "ES2018",
     "outDir": "dist",
     "declarationDir": "dist/types"
   }

--- a/packages/slimfast/package.json
+++ b/packages/slimfast/package.json
@@ -12,7 +12,7 @@
   },
   "types": "./dist/types",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "dist"

--- a/packages/slimfast/tsconfig.json
+++ b/packages/slimfast/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["src"],
   "extends": "tsconfig/tsconfig.json",
   "compilerOptions": {
-    "target": "es2016",
+    "target": "ES2018",
     "outDir": "dist",
     "declarationDir": "dist/types"
   }

--- a/packages/traverse-files/package.json
+++ b/packages/traverse-files/package.json
@@ -12,7 +12,7 @@
   },
   "types": "./dist/types",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "dist"

--- a/packages/workspace-node/package.json
+++ b/packages/workspace-node/package.json
@@ -12,7 +12,7 @@
   },
   "types": "./dist/types",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "dist"

--- a/packages/workspace-node/tsconfig.json
+++ b/packages/workspace-node/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["src"],
   "extends": "tsconfig/tsconfig.json",
   "compilerOptions": {
-    "target": "es2016",
+    "target": "ES2018",
     "outDir": "dist",
     "declarationDir": "dist/types"
   }

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -12,7 +12,7 @@
   },
   "types": "./dist/types/",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "dist"

--- a/packages/workspace/tsconfig.json
+++ b/packages/workspace/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["src"],
   "extends": "tsconfig/tsconfig.json",
   "compilerOptions": {
-    "target": "es2016",
+    "target": "ES2018",
     "outDir": "dist",
     "declarationDir": "dist/types"
   }


### PR DESCRIPTION
Due to the [LTS schedule of Node.js](https://nodejs.org/en/about/releases/), this PR updates the minimum required Node.js version to 18 for all packages. 

- Node.js 18 is in Active LTS status until October 2023, and Maintained until April 2025.
- This ensures that all packages stay up-to-date with the features and security updates from an actively maintained Node.js version.

