### PR TITLE
[slimfast-node]: Add JSDocs

### DIFF
--- a/.changeset/brown-trainers-pump.md
+++ b/.changeset/brown-trainers-pump.md
@@ -1,0 +1,5 @@
+---
+'@modular-rocks/slimfast-node': patch
+---
+
+Internal: Added JSDocs to `slimfast-node`

--- a/packages/slimfast-node/src/slimfast/index.ts
+++ b/packages/slimfast-node/src/slimfast/index.ts
@@ -10,15 +10,42 @@ import { name } from './pipeline/name';
 
 import type { SlimFastOpts } from '../types';
 
+/**
+ * It represents a workspace that contains both the original and refactored
+ * versions of a codebase. It offers methods to manage the
+ * codebase configurations.
+ */
 export class SlimFast extends SlimFastBase {
+  /**
+   * Initializes the SlimFast instance with the given configuration options.
+   *
+   * @param opts - Configuration options for the SlimFast instance.
+   *
+   * @example
+   * const slimfast = new SlimFast({ src: './src' });
+   */
   constructor(opts: SlimFastOpts) {
     super(opts);
   }
 
+  /**
+   * Returns a new Codebase instance with the given configuration options.
+   *
+   * @param opts - Configuration options for the new Codebase instance.
+   * @returns A new Codebase instance.
+   */
   newCodeBase(opts: SlimFastOpts) {
     return new Codebase(opts);
   }
 
+  /**
+   * Merges the provided configuration options with default pipeline options.
+   * Ensures that the configuration has default values for `visitors`, `namer`,
+   * `builder`, and `pipeline` if they are not provided.
+   *
+   * @param opts - The configuration options to be merged with default ones.
+   * @returns The merged configuration options containing both original and default values.
+   */
   defaultOptions(opts: SlimFastOpts) {
     super.defaultOptions(opts);
     const visitors: any[] = opts.visitors || [ExpressionVisitor];

--- a/packages/slimfast-node/src/slimfast/visitors/expression/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/expression/index.ts
@@ -12,7 +12,15 @@ import { removesTooMuch } from '../utils/contraints/removes-too-much';
 
 import type { RandomObject } from '../../../types';
 
+/**
+ * A `Visitor` that traverses AST expression nodes, evaluating them against specific constraints.
+ */
 export class ExpressionVisitor extends Visitor {
+  /**
+   * Provides a list of constraint functions for evaluating expressions during AST traversal.
+   *
+   * @returns An array of constraint functions specific to expressions.
+   */
   constraints(): Function[] {
     return [
       removesTooMuch(2),
@@ -27,6 +35,11 @@ export class ExpressionVisitor extends Visitor {
     ];
   }
 
+  /**
+   * This method is focused on AST nodes of type 'Expression'. For each node encountered during traversal, the method checks if it contains nested expressions. If not, it evaluates the node using the `test` method to determine if it meets the set criteria.
+   *
+   * @returns An object detailing how to process 'Expression' nodes during AST traversal.
+   */
   visit(): RandomObject {
     const test = this.test.bind(this);
     return {

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/contains-identifiers-in-other-scopes/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/contains-identifiers-in-other-scopes/index.ts
@@ -15,6 +15,24 @@ function isInsidePath(innerPath: NodePath, outerPath: NodePath): boolean {
   return false;
 }
 
+/**
+ * Checks if variables declared in a given AST node path are referenced or manipulated outside of their original declaring scope.
+ *
+ * This function specifically focuses on nodes that declare variables (`let`, `const`, `var`). It examines whether these variables are either accessed or manipulated in a different scope than their original declaration.
+ * This can be particularly useful for understanding dependencies or potential side-effects associated with variables.
+ *
+ * @param path - The AST node path of the variable declaration to be examined.
+ * @param data - Additional information or context related to the node.
+ * @param opts - Configuration options influencing the check.
+ * @param ast - The complete Abstract Syntax Tree.
+ * @returns `true` if any of the declared variables within the node path are referenced or manipulated outside their declaring scope, otherwise `false`.
+ *
+ * @example
+ * const hasExternalReferences = containsIdentifiersInOtherScopes(nodePath, data, opts, ast);
+ * if (hasExternalReferences) {
+ *   // Handle or analyze the variables that are used externally.
+ * }
+ */
 export const containsIdentifiersInOtherScopes = (
   path: NodePath,
   data: RandomObject,
@@ -23,6 +41,7 @@ export const containsIdentifiersInOtherScopes = (
 ) => {
   let usedInOtherScopes = false;
 
+  // TODO: double check this condition
   if (path.isVariableDeclaration()) {
     // most likely used in other scopes
     usedInOtherScopes = true;

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-assignment-expression/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-assignment-expression/index.ts
@@ -35,6 +35,23 @@ const isUsedInPath = (
   return false;
 };
 
+/**
+ * Determines if a given AST node path contains an assignment expression, and if the variables involved in that assignment are used in other scopes.
+ *
+ * The node path is examined for direct representations of an assignment expression. Additionally, nested nodes are inspected for assignment patterns, to determine if the assigned variables are referenced outside their original context.
+ *
+ * @param path - The AST node path to be checked.
+ * @param data - Information or context related to the node.
+ * @param opts - Configuration options.
+ * @param ast - The complete Abstract Syntax Tree.
+ * @returns `true` if the node path contains an assignment expression and the assigned variables are used in other scopes, otherwise `false`.
+ *
+ * @example
+ * const containsAssignment = hasAssignmentExpression(nodePath, data, opts, ast);
+ * if (containsAssignment) {
+ *   // Handle or flag the assignment for further analysis.
+ * }
+ */
 export const hasAssignmentExpression = (
   path: NodePath,
   data: RandomObject,

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-blocklisted-identifiers/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-blocklisted-identifiers/index.ts
@@ -3,14 +3,37 @@ import type { File } from '@babel/types';
 
 import type { RandomObject } from '../../../../../types';
 
+/**
+ * Generates a function to check if a given AST node path contains any identifiers that are part of a specified blocklist.
+ *
+ * The resulting function traverses the given node path and for every identifier node it encounters, it checks if that identifier's name is in the blocklist. This is particularly useful in scenarios where certain variable or function names might be considered undesirable or restricted.
+ *
+ * @param blocklisted - An array of identifiers considered to be blocklisted.
+ * @returns A function that evaluates if a node path contains any of the blocklisted identifiers.
+ * @example
+ * const isIdentifierBlocklisted = hasBlocklistedIdentifiers(['useEffect', 'useMemo']);
+ * const isBlocklisted = isIdentifierBlocklisted(nodePath, data, opts, ast);
+ * if (isBlocklisted) {
+ *   // Handle the blocklisted identifier.
+ * }
+ */
 export const hasBlocklistedIdentifiers =
-  (blocklised: string[]) =>
+  (blocklisted: string[]) =>
+  /**
+   * Determines if the provided AST node path contains any blocklisted identifiers.
+   *
+   * @param path - The AST node path to be examined.
+   * @param data - Information or context related to the node.
+   * @param opts - Configuration options.
+   * @param ast - The complete Abstract Syntax Tree.
+   * @returns `true` if any of the identifiers within the node path are blocklisted, otherwise `false`.
+   */
   (path: NodePath, data: RandomObject, opts: RandomObject, ast: File) => {
     let itHasBlocklistedIdentifiers = false;
 
     path.traverse({
       Identifier(innerPath: RandomObject) {
-        if (blocklised.includes(innerPath.node.name)) {
+        if (blocklisted.includes(innerPath.node.name)) {
           itHasBlocklistedIdentifiers = true;
         }
       },

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-return-statement/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-return-statement/index.ts
@@ -3,6 +3,25 @@ import { isAFunction } from '../is-a-function';
 
 import type { RandomObject } from '../../../../../types';
 
+/**
+ * Determines if a given AST node path represents a return statement or contains a return statement not within a nested function.
+ *
+ * This function examines the provided node path for two conditions:
+ * 1. The path directly represents a return statement.
+ * 2. The path contains a return statement that isn't nested within any type of function.
+ *
+ * @param path - The AST node path to be checked.
+ * @param data - Information or context related to the node.
+ * @param opts - Configuration options.
+ * @param ast - The complete Abstract Syntax Tree.
+ * @returns `true` if either condition is met, otherwise `false`.
+ *
+ * @example
+ * const hasReturn = hasReturnStatement(nodePath, data, opts, ast);
+ * if (hasReturn) {
+ *   // Handle the problematic return statement.
+ * }
+ */
 export const hasReturnStatement = (
   path: NodePath,
   data: RandomObject,

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-variable-declarator/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-variable-declarator/index.ts
@@ -2,11 +2,25 @@ import { NodePath, Node } from '@babel/traverse';
 
 import type { RandomObject } from '../../../../../types';
 
-// This method will return false if the path is a VariableDeclarator
-// I can be followed by the isVariableDeclaration constraint that will test the full declaration
-// If the VariableDeclarator path is extracted then it will not take the type of declaration with it
-// e.g. the path will be `hello = 'hello'` rather than `const hello = 'hello'`
-// In summary, if this constraint is followed by a VariableDeclarator constraint, then the VariableDeclarator constraint will test this type of path
+/**
+ * Determines if a given AST node path represents a variable declarator.
+ *
+ * A variable declarator is the part of a variable declaration that captures the actual variable
+ * name and its initial value without its declaration keyword (`var`, `let`, `const`). For example,
+ * in the declaration `const hello = 'world';`, the variable declarator represents `hello = 'world'`.
+ *
+ * @param path - The AST node path to be checked. This can either be a proper NodePath or an object that behaves similarly.
+ * @param data - Information or context related to the node.
+ * @param opts - Configuration options influencing the check.
+ * @param ast - The complete Abstract Syntax Tree.
+ * @returns `true` if the node represents a variable declarator, otherwise `false`.
+ *
+ * @example
+ * const isVarDeclarator = hasVariableDeclarator(nodePath, data, opts, ast);
+ * if (isVarDeclarator) {
+ *   // Handle the variable declarator node.
+ * }
+ */
 export const hasVariableDeclarator = (
   path: NodePath | RandomObject,
   data: RandomObject,

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/identifiers-not-within-range/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/identifiers-not-within-range/index.ts
@@ -3,8 +3,30 @@ import { identifiersWithinRange } from '../identifiers-within-range';
 
 import type { RandomObject } from '../../../../../types';
 
+/**
+ * Generates a function to determine if the number of identifiers within an AST node path does not fall within a specified range.
+ *
+ * The created function leverages the `identifiersWithinRange` method and returns the opposite of its result, i.e., if `identifiersWithinRange` returns `true`, this function will return `false` and vice versa.
+ *
+ * @param min - The minimum number of identifiers the node should not contain (inclusive).
+ * @param max - The maximum number of identifiers the node should not contain (inclusive).
+ * @returns A function that evaluates if a node path contains identifiers outside the specified range.
+ * @example
+ * const isOutsideRange = identifiersNotWithinRange(2, 4);
+ * const result = isOutsideRange(nodePath, data, opts, ast);
+ * // Returns true if nodePath contains less than 2 or more than 4 identifiers.
+ */
 export const identifiersNotWithinRange =
   (min: number, max: number) =>
+  /**
+   * Determines if the number of identifiers within a given AST node path is outside the specified range.
+   *
+   * @param path - The AST node path to be examined.
+   * @param data - Information or context related to the node.
+   * @param opts - Configuration options influencing the check.
+   * @param ast - The complete Abstract Syntax Tree.
+   * @returns `true` if the number of identifiers lies outside the specified range, otherwise `false`.
+   */
   (path: NodePath, data: RandomObject, opts: RandomObject, ast: Node) => {
     return !identifiersWithinRange(min, max)(path, data, opts, ast);
   };

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/identifiers-within-range/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/identifiers-within-range/index.ts
@@ -3,8 +3,30 @@ import { extractIdentifiers } from '../../extract-identifiers';
 
 import type { RandomObject } from '../../../../../types';
 
+/**
+ * Generates a function to determine if the number of identifiers within an AST node path falls within a specified range.
+ *
+ * The created function first extracts identifiers from the provided node path using the `extractIdentifiers` method. After extraction, it checks if the count of identifiers lies within the provided `min` and `max` range.
+ *
+ * @param min - The minimum number of identifiers the node should contain (inclusive). Defaults to 2.
+ * @param max - The maximum number of identifiers the node should contain (inclusive). Defaults to 4.
+ * @returns A function that evaluates if a node path contains identifiers within the specified range.
+ * @example
+ * const isWithinRange = identifiersWithinRange(2, 4);
+ * const result = isWithinRange(nodePath, data, opts, ast);
+ * // Returns true if nodePath contains between 2 and 4 identifiers, inclusive.
+ */
 export const identifiersWithinRange =
   (min: number, max: number) =>
+  /**
+   * Determines if the number of identifiers within a given AST node path is within the specified range.
+   *
+   * @param path - The AST node path to be examined.
+   * @param data - Information or context related to the node.
+   * @param opts - Configuration options influencing the check.
+   * @param ast - The complete Abstract Syntax Tree.
+   * @returns `true` if the number of identifiers lies within the specified range, otherwise `false`.
+   */
   (path: NodePath, data: RandomObject, opts: RandomObject, ast: Node) => {
     extractIdentifiers(path, data, opts, ast);
 

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-a-function/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-a-function/index.ts
@@ -2,6 +2,24 @@ import { NodePath, Node } from '@babel/traverse';
 
 import type { RandomObject } from '../../../../../types';
 
+/**
+ * Determines if a given AST node path represents any kind of function.
+ *
+ * This function checks if the provided node path type corresponds to any of the
+ * standard JavaScript function types (e.g., regular functions, arrow functions, class methods).
+ *
+ * @param path - The AST node path to be checked.
+ * @param data - Information or context related to the node.
+ * @param opts - Configuration options.
+ * @param ast - The complete Abstract Syntax Tree.
+ * @returns `true` if the node represents any kind of function, otherwise `false`.
+ *
+ * @example
+ * const isFunctionNode = isAFunction(nodePath, data, opts, ast);
+ * if (isFunctionNode) {
+ *   // Handle the function node.
+ * }
+ */
 export const isAFunction = (
   path: NodePath,
   data: RandomObject,

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-call-expression/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-call-expression/index.ts
@@ -2,6 +2,24 @@ import { NodePath, Node } from '@babel/traverse';
 
 import type { RandomObject } from '../../../../../types';
 
+/**
+ * Determines if a given AST node path represents a call expression within an expression statement.
+ *
+ * This function checks if the type of the provided node is 'ExpressionStatement' and the type
+ * of its contained expression is 'CallExpression'.
+ *
+ * @param path - The AST node path to be checked.
+ * @param data - Information or context related to the node
+ * @param opts - Configuration options
+ * @param ast - The complete Abstract Syntax Tree
+ * @returns `true` if the node represents a call expression within an expression statement, otherwise `false`.
+ *
+ * @example
+ * const isItACallExpression = isCallExpression(nodePath, data, opts, ast);
+ * if (isItACallExpression) {
+ *   // Handle the call expression.
+ * }
+ */
 export const isCallExpression = (
   path: NodePath,
   data: RandomObject,

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/removes-too-much/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/removes-too-much/index.ts
@@ -12,8 +12,29 @@ const getSize = (node: Node): number => {
   return notANumber(start) || notANumber(end) ? 0 : end - start;
 };
 
+/**
+ * Generates a function to determine if removing a given AST node would reduce the overall size of the AST too significantly.
+ *
+ * This is based on a comparison of the size of the node (measured in characters from start to end) and the size of the entire AST. If the node's size, when multiplied by a provided multiplier, exceeds the total size of the AST, then it is considered as removing too much.
+ *
+ * @param multiplier - Factor by which the size of the node is multiplied.
+ * @returns A function that checks if the removal of a node path would reduce the AST size too significantly.
+ * @example
+ * const wouldRemoveTooMuch = removesTooMuch(2);
+ * const significantReduction = wouldRemoveTooMuch(nodePath, data, opts, ast);
+ * // Returns true if the removal would be too significant.
+ */
 export const removesTooMuch =
   (multiplier: number) =>
+  /**
+   * Determines if the removal of a specific AST node would lead to a disproportionate reduction in the overall size of the AST.
+   *
+   * @param path - The AST node path under evaluation.
+   * @param data - Information or context related to the node.
+   * @param opts - Configuration options influencing the check.
+   * @param ast - The complete Abstract Syntax Tree.
+   * @returns `true` if the removal of the node would cause a significant reduction in the AST's size, otherwise `false`.
+   */
   (path: NodePath, data: RandomObject, opts: RandomObject, ast: Node) => {
     const astSize = getSize(ast);
     const size = getSize(path.node);

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/should-ignore/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/should-ignore/index.ts
@@ -2,6 +2,25 @@ import Traverse, { NodePath, Node } from '@babel/traverse';
 
 import type { RandomObject } from '../../../../../types';
 
+/**
+ * Determines if a given AST node path contains either a `Super` or a `YieldExpression` node.
+ *
+ * This function traverses the AST represented by the provided node path and checks for the presence
+ * of specific node types (i.e., `Super` or `YieldExpression`). If either type is found, it indicates
+ * that the original node should be ignored in any subsequent operations or analyses.
+ *
+ * @param path - The AST node path to be examined.
+ * @param data - Information or context related to the node.
+ * @param opts - Configuration options influencing the check.
+ * @param ast - The complete Abstract Syntax Tree.
+ * @returns `true` if the node contains either a `Super` or `YieldExpression` node, otherwise `false`.
+ *
+ * @example
+ * const nodeShouldBeIgnored = shouldIgnore(nodePath, data, opts, ast);
+ * if (nodeShouldBeIgnored) {
+ *   // Skip processing or analysis for this node
+ * }
+ */
 export function shouldIgnore(
   path: NodePath,
   data: RandomObject,

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/too-small/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/too-small/index.ts
@@ -12,8 +12,29 @@ const getSize = (node: Node): number => {
   return notANumber(start) || notANumber(end) ? 0 : end - start;
 };
 
+/**
+ * Generates a function to check if an AST node is "too small" based on size and associated identifiers.
+ *
+ * @param multiplier - Factor used for calculating minimum size from identifiers' length. Defaults to 1.5.
+ * @param minLength - Minimum length threshold for the node. Defaults to 50.
+ * @param measureIdentifiers - Whether to compare node size against identifier-based size. Defaults to true.
+ * @returns A function that evaluates if a node path is "too small".
+ * @example
+ * const isNodeTooSmall = tooSmall(1.5, 50, true);
+ * const small = isNodeTooSmall(nodePath, data, opts, ast);
+ * // Returns true if node is too small.
+ */
 export const tooSmall =
   (multiplier: number, minLength: number, measureIdentifiers?: Boolean) =>
+  /**
+   * Evaluates if an AST node path is "too small" based on its size and associated identifiers.
+   *
+   * @param path - The AST node path under evaluation.
+   * @param data - Information about the node, especially `toInject` which lists associated identifiers.
+   * @param opts - Configuration options influencing the check.
+   * @param ast - The complete Abstract Syntax Tree.
+   * @returns `true` if the node path is "too small", otherwise `false`.
+   */
   (path: NodePath, data: RandomObject, opts: RandomObject, ast: Node) => {
     multiplier = multiplier || 1.5;
     minLength = minLength || 50;

--- a/packages/slimfast-node/src/slimfast/visitors/utils/extract-identifiers/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/extract-identifiers/index.ts
@@ -23,6 +23,32 @@ const buildBinding = (name: string, binding: Binding): Binding => {
   // }
 };
 
+/**
+ * Traverses a given Abstract Syntax Tree (AST) node path and extracts bindings associated with any `Identifier` nodes.
+ *
+ * The function categorizes the extracted bindings into two main groups:
+ * - `toImport`: Contains bindings that are related to import statements.
+ * - `toInject`: Contains bindings that are associated with variable declarations or function parameters.
+ *
+ * These categorized bindings are added to the provided `data` object under the respective keys.
+ *
+ * @param path - The starting AST node path to be traversed.
+ * @param data - An object to which the categorized bindings will be added.
+ * @param opts - Optional configuration options.
+ * @param ast - The entire AST, if available.
+ * @returns This function modifies the `data` object in-place and doesn't return a value.
+ *
+ * @example
+ * const code = `import React from 'react'; const greet = (name) => "Hello, " + name;`;
+ * const ast = parser(code);
+ * const data = {};
+ * traverse(ast, {
+ *   Program(path) {
+ *     extractIdentifiers(path, data);
+ *   }
+ * });
+ * // Now, `data.toImport` contains the binding related to `React` and `data.toInject` contains the binding related to `greet`.
+ */
 export const extractIdentifiers = (
   path: NodePath,
   data: RandomObject,

--- a/packages/slimfast-node/src/slimfast/visitors/utils/not-in-extracted/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/not-in-extracted/index.ts
@@ -1,5 +1,22 @@
 import { NodePath, Node } from '@babel/traverse';
 
+/**
+ * Determines if a given Abstract Syntax Tree (AST) node or any of its parent nodes is not present in the provided `extracted` map.
+ *
+ * The function starts from the specified node (`path`) and traverses its parent nodes to see if any of them
+ * exist in the `extracted` map. If any node is found in the map, the function returns `false`, indicating
+ * that the node or one of its parent nodes is already extracted. Otherwise, it returns `true`, signifying
+ * that neither the node nor its parent nodes are in the `extracted` map.
+ *
+ * @param path - The starting AST node path from which to check its and its parents' presence in the map.
+ * @param extracted - A map containing previously extracted AST nodes.
+ * @returns Returns `true` if the provided node and all its parent nodes are not in the `extracted` map, otherwise `false`.
+ *
+ * @example
+ * if (notInExtracted(nodePath, extractedNodesMap)) {
+ *   // The node and its parents are not in the extracted map.
+ * }
+ */
 export const notInExtracted = (
   path: NodePath,
   extracted: Map<NodePath, any>

--- a/packages/slimfast-node/src/slimfast/visitors/utils/parser/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/parser/index.ts
@@ -8,4 +8,19 @@ const babelConfig: RandomObject = {
   plugins: ['jsx', ['typescript', { isTSX: true }], 'babel-plugin-recast'],
 };
 
+/**
+ * Parses a given JavaScript or TypeScript code string into its corresponding Abstract Syntax Tree (AST) representation.
+ *
+ * This function utilizes Babel's parser with a predefined configuration suitable for
+ * modern JavaScript and TypeScript code, including JSX. The configuration also ensures
+ * the generation of parenthesized expressions and integrates the 'babel-plugin-recast' for further AST manipulations.
+ *
+ * @param code - The JavaScript or TypeScript code string to be parsed.
+ * @returns The Abstract Syntax Tree representation of the provided code.
+ *
+ * @example
+ * const code = `const greet = (name) => "Hello, " + name + "!";`;
+ * const ast = parser(code);
+ * // `ast` now contains the AST representation of the given code string.
+ */
 export const parser = (code: string) => babelParser.parse(code, babelConfig);

--- a/packages/slimfast-node/src/slimfast/visitors/utils/reject-parents-with-types/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/reject-parents-with-types/index.ts
@@ -1,5 +1,24 @@
 import { NodePath } from '@babel/traverse';
 
+/**
+ * Checks if a given AST node or any of its parent nodes are of a type specified in the `blacklistedParents` array.
+ *
+ * The function traverses up the parent nodes of the given node (`path`) and checks
+ * each node's type against the provided list of blacklisted parent types. If any parent
+ * node's type matches an entry in the blacklisted list, the function returns `false`,
+ * indicating that the path has a blacklisted parent. Otherwise, it returns `true`,
+ * signifying that none of the parent nodes are of a blacklisted type.
+ *
+ * @param path - The starting AST node path from which to check its parent nodes.
+ * @param blacklistedParents - An array of AST node types that should be considered as blacklisted.
+ * @returns Returns `true` if none of the parent nodes are of a blacklisted type, otherwise `false`.
+ *
+ * @example
+ * const isEligible = rejectParentsWithTypes(nodePath, ['ImportDeclaration', 'TypeParameterDeclaration']);
+ * if(isEligible) {
+ *   // Process the node
+ * }
+ */
 export function rejectParentsWithTypes(
   path: NodePath | null,
   blacklistedParents: string[]

--- a/packages/slimfast-node/src/slimfast/visitors/visitor/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/visitor/index.ts
@@ -5,15 +5,43 @@ import { notInExtracted } from '../utils/not-in-extracted';
 
 import type { RandomObject } from '../../../types';
 
+/**
+ * The Visitor class is responsible for traversing the AST and managing extraction based on
+ * provided constraints and blocklisted parent types.
+ */
 export class Visitor {
+  /**
+   * A map storing extracted nodes from the AST.
+   */
   extracted: Map<NodePath, any>;
 
+  /**
+   * The abstract syntax tree that the Visitor will traverse.
+   */
   ast: Node | undefined;
 
+  /**
+   * Options passed to the Visitor.
+   */
   opts: RandomObject;
 
+  /**
+   * Stateful information for the Visitor.
+   */
   state: RandomObject;
 
+  /**
+   * Initializes the Visitor instance with the provided abstract syntax tree (AST), options,
+   * state information, and a map of extracted nodes. It also triggers the traversal of the AST.
+   *
+   * @param ast - The abstract syntax tree to be traversed by the visitor.
+   * @param opts - Configuration options provided to the Visitor.
+   * @param state - Stateful information to manage the extraction and traversal.
+   * @param extracted - A map storing nodes that have been extracted from the AST.
+   *
+   * @example
+   * const visitor = new Visitor(ast, options, state, extractedNodes);
+   */
   constructor(
     ast: Node | undefined,
     opts: RandomObject,
@@ -27,10 +55,42 @@ export class Visitor {
     this.traverse();
   }
 
+  /**
+   * Provides a list of constraint functions to be applied during AST traversal.
+   * Each constraint function is expected to check specific conditions on AST nodes.
+   * By default, this method returns an empty array, meaning no constraints are applied.
+   * It's intended to be overridden by subclasses or instances to provide specific constraints.
+   *
+   * A constraint function should return `true` if the provided AST node violates the constraint,
+   * and `false` otherwise.
+   *
+   * @returns An array of constraint functions.
+   *
+   * @example
+   * // A constraint to check if a node type is 'Identifier'
+   * function isIdentifier(path) {
+   *   return path.type === 'Identifier';
+   * }
+   *
+   * // Overriding constraints in a subclass or instance
+   * constraints() {
+   *   return [isIdentifier];
+   * }
+   */
   constraints(): Function[] {
     return [];
   }
 
+  /**
+   * Provides a list of blocklisted parent node types that should be avoided during AST traversal.
+   * These types represent parent nodes that, if encountered, will cause the current node to be
+   * considered ineligible for extraction.
+   *
+   * The blocklisted parent types can be provided via the `opts` object during instantiation,
+   * or a default list is used if none are provided.
+   *
+   * @returns An array of blocklisted parent node types.
+   */
   blocklistedParents(): string[] {
     return (
       this.opts.blocklistedParents || [
@@ -40,6 +100,15 @@ export class Visitor {
     );
   }
 
+  /**
+   * Checks if a given AST node (`path`) passes all the constraints defined by the `constraints` method.
+   * If the node violates any single constraint, this method returns `false`.
+   *
+   * @param path - The AST node to be checked.
+   * @param data - Additional data or context related to the AST node.
+   * @returns Returns `true` if the node passes all constraints, otherwise `false`.
+   *
+   */
   passesContraints(path: NodePath, data: RandomObject): Boolean {
     if (
       this.constraints().some((constraint: Function) =>
@@ -52,6 +121,17 @@ export class Visitor {
     return true;
   }
 
+  /**
+   * Determines if a given AST node (`path`) is ineligible for processing.
+   *
+   * A node is considered ineligible if:
+   *  - It doesn't have a parent node.
+   *  - It has already been extracted.
+   *  - It has a parent of a blocklisted node type.
+   *
+   * @param path - The AST node to check for eligibility.
+   * @returns Returns `true` if the node is ineligible, `false` if it is eligible, and `null` if the node has no parent.
+   */
   notEligible(path: NodePath): Boolean | null {
     const eligible =
       path.parentPath &&
@@ -60,6 +140,18 @@ export class Visitor {
     return !eligible;
   }
 
+  /**
+   * Evaluates the eligibility of a given AST node (`path`) for extraction and extracts it if applicable.
+   *
+   * The method checks:
+   * 1. If the node is ineligible using the `notEligible` method.
+   * 2. If the node or any of its parent nodes pass the constraints set by the `passesContraints` method.
+   *
+   * If the node itself or any of its parent nodes pass the constraints, the node (or the qualifying parent) is added
+   * to the `extracted` map, which keeps track of all nodes that have been extracted.
+   *
+   * @param path - The AST node to be evaluated for extraction.
+   */
   test(path: NodePath): void {
     if (this.notEligible(path)) return;
 
@@ -75,24 +167,53 @@ export class Visitor {
     }
   }
 
+  /**
+   * Provides the visitor methods for the Abstract Syntax Tree (AST) traversal.
+   * Each method in the returned object specifies how to process a particular type of AST node.
+   *
+   * @returns An object where keys represent AST node types and values are functions
+   * detailing how to process those nodes.
+   *
+   * @example
+   * // Overriding `visit` in a subclass or instance to process 'Expression' nodes
+   * visit() {
+   *   return {
+   *     Expression(path: NodePath) {
+   *       // Custom processing logic for 'Expression' nodes
+   *     }
+   *   };
+   * }
+   */
   visit(): RandomObject {
     // TODO: maybe use composition to fix this
     // eslint-disable-next-line no-console
     console.warn('Override this method, this is just an example');
     return {};
-    // const test = this.test
-    // return {
-    //   Expression(path: NodePath) {
-    //     test(path)
-    //   }
-    // }
   }
 
+  /**
+   * Initiates the traversal of the Abstract Syntax Tree (AST) using the provided visitor methods.
+   *
+   * The `traverse` method goes through each node of the AST and applies the corresponding visitor
+   * methods defined in the `visit` method. If an AST is not provided, the traversal
+   * will not occur.
+   */
   traverse(): void {
     if (!this.ast) return;
     traverse(this.ast, this.visit());
   }
 
+  /**
+   * Converts and returns the extracted nodes from the AST as an array.
+   *
+   * The `extracted` property of the `Visitor` class is a map that keeps track of nodes
+   * which have been extracted during AST traversal. This method provides these nodes
+   * in an array format.
+   *
+   * @returns An array of extracted nodes. Each item in the
+   * array is a tuple where the first element is the node path and the second element
+   * is associated data or context for that node.
+   */
   extract() {
     return Array.from(this.extracted);
   }


### PR DESCRIPTION
This PR introduces JSDocs to a portion of the `slimfast-node` package.
This will be followed by another PR to complete the JSDocs documentation across the entire package.
