### PR TITLE
Refactor imports and update ESLint rules

### DIFF
--- a/.changeset/ninety-turtles-invite.md
+++ b/.changeset/ninety-turtles-invite.md
@@ -1,0 +1,10 @@
+---
+'@modular-rocks/traverse-files': patch
+'@modular-rocks/workspace-node': patch
+'@modular-rocks/slimfast-node': patch
+'eslint-config-custom': patch
+'@modular-rocks/workspace': patch
+'@modular-rocks/slimfast': patch
+---
+
+Internal: Refactored imports across all packages and modified eslint rules for better code consistency.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Linting
         run: pnpm lint
+
+      - name: Format
+        run: pnpm check:format

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "trailingComma": "es5",
-  "singleQuote": true
+  "singleQuote": true,
+  "endOfLine": "lf"
 }

--- a/config/eslint-config/.eslintrc.cjs
+++ b/config/eslint-config/.eslintrc.cjs
@@ -1,30 +1,22 @@
+/**
+ * @type {import("eslint").Linter.Config}
+ */
 module.exports = {
   env: {
     commonjs: true,
     es2021: true,
     node: true,
   },
-  extends: [
-    'airbnb-base',
-    'airbnb-typescript/base',
-    'plugin:prettier/recommended',
-  ],
+  extends: ['airbnb-base', 'airbnb-typescript/base', 'prettier'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2021,
     sourceType: 'module',
     project: './tsconfig.json',
   },
-  plugins: ['@typescript-eslint', 'prettier'],
+  plugins: ['@typescript-eslint', 'unused-imports'],
   rules: {
     '@typescript-eslint/no-require-imports': 'error',
-    'prettier/prettier': [
-      'error',
-      {
-        usePrettierrc: true,
-        endOfLine: 'auto',
-      },
-    ],
     'import/extensions': [
       'error',
       'ignorePackages',
@@ -42,10 +34,33 @@ module.exports = {
     'no-await-in-loop': 'off',
     'no-async-promise-executor': 'off',
     '@typescript-eslint/no-useless-constructor': 'off',
-    'import/no-cycle': 'off',
     'import/no-extraneous-dependencies': 'off', // needed for the monorepo
     'import/prefer-default-export': 'off',
     '@typescript-eslint/no-floating-promises': 'error',
+    'arrow-body-style': 'off',
+    '@typescript-eslint/consistent-type-imports': 'error',
+    '@typescript-eslint/consistent-type-exports': 'error',
+    'import/order': [
+      'error',
+      {
+        groups: [
+          ['builtin', 'internal'],
+          'external',
+          ['index', 'parent', 'sibling'],
+          'object',
+          'type',
+        ],
+        distinctGroup: true,
+        'newlines-between': 'always',
+        alphabetize: {
+          order: 'asc',
+          orderImportKind: 'asc',
+          caseInsensitive: true,
+        },
+        warnOnUnassignedImports: true,
+      },
+    ],
+    'unused-imports/no-unused-imports': 'error',
   },
 
   ignorePatterns: ['.eslintrc.cjs', 'dist', 'turbo', 'coverage'],

--- a/config/eslint-config/package.json
+++ b/config/eslint-config/package.json
@@ -11,6 +11,6 @@
     "eslint-config-airbnb-typescript": "17.1.0",
     "eslint-config-prettier": "9.0.0",
     "eslint-plugin-import": "2.28.1",
-    "eslint-plugin-prettier": "5.0.0"
+    "eslint-plugin-unused-imports": "3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "coverage": "turbo run coverage",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
+    "check:format": "prettier --check \"**/*.{ts,tsx,md}\"",
+    "check": "pnpm lint && pnpm check:format",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "release": "changeset publish"
   },

--- a/packages/slimfast-node/src/slimfast/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/index.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'vitest';
 
 import { SlimFast } from '.';
-import before from '../../test-results/basic/before';
 import after from '../../test-results/basic/after';
+import before from '../../test-results/basic/before';
 
 import type { SlimFastOpts } from '../types';
 

--- a/packages/slimfast-node/src/slimfast/index.ts
+++ b/packages/slimfast-node/src/slimfast/index.ts
@@ -1,12 +1,12 @@
-import { Codebase } from '@modular-rocks/workspace-node';
 import { SlimFast as SlimFastBase } from '@modular-rocks/slimfast';
+import { Codebase } from '@modular-rocks/workspace-node';
 
-import { ExpressionVisitor } from './visitors/expression';
-import { defaultFunctionNameGenerator } from './pipeline/name/default-function-name-generator';
+import { build } from './pipeline/build';
 import { builder as pipelineBuilder } from './pipeline/build/builder';
 import { extract } from './pipeline/extract';
-import { build } from './pipeline/build';
 import { name } from './pipeline/name';
+import { defaultFunctionNameGenerator } from './pipeline/name/default-function-name-generator';
+import { ExpressionVisitor } from './visitors/expression';
 
 import type { SlimFastOpts } from '../types';
 

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/combine-imports/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/combine-imports/index.test.ts
@@ -1,14 +1,15 @@
-import unique from 'array-unique';
+import traverse from '@babel/traverse';
 import { program } from '@babel/types';
-import traverse, { Binding, NodePath } from '@babel/traverse';
 import { Codebase, FileContainer } from '@modular-rocks/workspace-node';
+import unique from 'array-unique';
 import { describe, expect, test } from 'vitest';
 
 import { combineImports } from '.';
-import { parser } from '../../../../visitors/utils/parser';
 import { extractIdentifiers } from '../../../../visitors/utils/extract-identifiers';
+import { parser } from '../../../../visitors/utils/parser';
 
 import type { RandomObject, SlimFastOpts } from '../../../../../types';
+import type { Binding, NodePath } from '@babel/traverse';
 
 const files: [string, string][] = [[`/path`, '']];
 const opts: SlimFastOpts = {

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/combine-imports/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/combine-imports/index.ts
@@ -1,10 +1,6 @@
 import { dirname, relative, resolve } from 'path/posix';
 
-import { Binding } from '@babel/traverse';
 import {
-  ImportDefaultSpecifier,
-  ImportNamespaceSpecifier,
-  ImportSpecifier,
   identifier,
   importDeclaration,
   importDefaultSpecifier,
@@ -15,6 +11,12 @@ import {
 import unique from 'array-unique';
 
 import type { RandomObject } from '../../../../../types';
+import type { Binding } from '@babel/traverse';
+import type {
+  ImportDefaultSpecifier,
+  ImportNamespaceSpecifier,
+  ImportSpecifier,
+} from '@babel/types';
 
 interface Entry {
   default?: string | null;

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/import-statement/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/import-statement/index.test.ts
@@ -1,6 +1,4 @@
-import unique from 'array-unique';
-import { program } from '@babel/types';
-import traverse, { NodePath } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { Codebase, FileContainer } from '@modular-rocks/workspace-node';
 import { describe, expect, test } from 'vitest';
 
@@ -8,6 +6,7 @@ import { generateImportDeclaration } from '.';
 import { parser } from '../../../../visitors/utils/parser';
 
 import type { SlimFastOpts } from '../../../../../types';
+import type { NodePath } from '@babel/traverse';
 
 const files: [string, string][] = [[`/path`, '']];
 const opts: SlimFastOpts = {

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/index.ts
@@ -1,6 +1,5 @@
 import { dirname, extname, resolve } from 'path/posix';
 
-import { NodePath } from '@babel/traverse';
 import { program } from '@babel/types';
 import unique from 'array-unique';
 
@@ -10,6 +9,7 @@ import { replace as replaceInOriginalFile } from './replace';
 import { wrap } from './wrap';
 
 import type { RandomObject, SlimFastOpts } from '../../../../types';
+import type { NodePath } from '@babel/traverse';
 
 /**
  * Builds the AST for a module, manages its imports, and optionally replaces nodes in the original file.

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/replace/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/replace/index.test.ts
@@ -1,10 +1,10 @@
-import traverse, { NodePath } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { Codebase, FileContainer } from '@modular-rocks/workspace-node';
 import { describe, expect, test } from 'vitest';
 
 import { replace } from '.';
-import { parser } from '../../../../visitors/utils/parser';
 import { extractIdentifiers } from '../../../../visitors/utils/extract-identifiers';
+import { parser } from '../../../../visitors/utils/parser';
 
 import type { SlimFastOpts } from '../../../../../types';
 

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/replace/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/replace/index.ts
@@ -1,9 +1,8 @@
-import { NodePath } from '@babel/traverse';
-
 import { generateJSXElement } from './jsx-function';
 import { generateFunction as generateCalleeFunction } from './normal-function';
 
 import type { RandomObject, SlimFastOpts } from '../../../../../types';
+import type { NodePath } from '@babel/traverse';
 
 /**
  * Replaces a `node path` with a newly generated AST node, which could be a JSX element

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/replace/jsx-function/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/replace/jsx-function/index.test.ts
@@ -1,12 +1,13 @@
-import traverse, { NodePath } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { Codebase, FileContainer } from '@modular-rocks/workspace-node';
 import { describe, expect, test } from 'vitest';
 
 import { generateJSXElement } from '.';
-import { parser } from '../../../../../visitors/utils/parser';
 import { extractIdentifiers } from '../../../../../visitors/utils/extract-identifiers';
+import { parser } from '../../../../../visitors/utils/parser';
 
 import type { SlimFastOpts } from '../../../../../../types';
+import type { NodePath } from '@babel/traverse';
 
 const files: [string, string][] = [[`/path`, '']];
 const opts: SlimFastOpts = {

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/replace/jsx-function/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/replace/jsx-function/index.ts
@@ -1,4 +1,3 @@
-import unique from 'array-unique';
 import {
   jsxIdentifier,
   jsxOpeningElement,
@@ -8,6 +7,7 @@ import {
   identifier,
   jsxClosingElement,
 } from '@babel/types';
+import unique from 'array-unique';
 
 import type { RandomObject } from '../../../../../../types';
 

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/replace/normal-function/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/replace/normal-function/index.test.ts
@@ -1,12 +1,13 @@
-import traverse, { NodePath } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { Codebase, FileContainer } from '@modular-rocks/workspace-node';
 import { describe, expect, test } from 'vitest';
 
 import { generateFunction } from '.';
-import { parser } from '../../../../../visitors/utils/parser';
 import { extractIdentifiers } from '../../../../../visitors/utils/extract-identifiers';
+import { parser } from '../../../../../visitors/utils/parser';
 
 import type { SlimFastOpts } from '../../../../../../types';
+import type { NodePath } from '@babel/traverse';
 
 const files: [string, string][] = [[`/path`, '']];
 const opts: SlimFastOpts = {

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/replace/normal-function/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/replace/normal-function/index.ts
@@ -1,5 +1,5 @@
-import unique from 'array-unique';
 import { identifier, callExpression } from '@babel/types';
+import unique from 'array-unique';
 
 import type { RandomObject } from '../../../../../../types';
 

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/has-await/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/has-await/index.test.ts
@@ -1,6 +1,4 @@
-import unique from 'array-unique';
-import { program } from '@babel/types';
-import traverse, { NodePath } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { Codebase, FileContainer } from '@modular-rocks/workspace-node';
 import { describe, expect, test } from 'vitest';
 
@@ -8,6 +6,7 @@ import { hasAwait } from '.';
 import { parser } from '../../../../../visitors/utils/parser';
 
 import type { SlimFastOpts } from '../../../../../../types';
+import type { NodePath } from '@babel/traverse';
 
 const files: [string, string][] = [[`/path`, '']];
 const opts: SlimFastOpts = {

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/has-await/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/has-await/index.ts
@@ -1,4 +1,6 @@
-import traverse, { NodePath } from '@babel/traverse';
+import traverse from '@babel/traverse';
+
+import type { NodePath } from '@babel/traverse';
 
 /**
  * Checks if the provided AST node path contains an `await` expression.

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/index.test.ts
@@ -1,12 +1,13 @@
-import traverse, { NodePath } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { Codebase, FileContainer } from '@modular-rocks/workspace-node';
 import { describe, expect, test } from 'vitest';
 
 import { wrap } from '.';
-import { parser } from '../../../../visitors/utils/parser';
 import { extractIdentifiers } from '../../../../visitors/utils/extract-identifiers';
+import { parser } from '../../../../visitors/utils/parser';
 
 import type { SlimFastOpts } from '../../../../../types';
+import type { NodePath } from '@babel/traverse';
 
 const files: [string, string][] = [[`/path`, '']];
 const opts: SlimFastOpts = {

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/index.ts
@@ -1,9 +1,8 @@
-import { NodePath } from '@babel/traverse';
-
 import { generateExportedJSXComponent } from './jsx-function';
 import { generateExportedFunction } from './normal-function';
 
 import type { RandomObject, SlimFastOpts } from '../../../../../types';
+import type { NodePath } from '@babel/traverse';
 
 /**
  * Wraps the provided AST node path into an exported default function or JSX component.

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/jsx-function/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/jsx-function/index.test.ts
@@ -1,12 +1,13 @@
-import traverse, { NodePath } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { Codebase, FileContainer } from '@modular-rocks/workspace-node';
 import { describe, expect, test } from 'vitest';
 
 import { generateExportedJSXComponent } from '.';
-import { parser } from '../../../../../visitors/utils/parser';
 import { extractIdentifiers } from '../../../../../visitors/utils/extract-identifiers';
+import { parser } from '../../../../../visitors/utils/parser';
 
 import type { SlimFastOpts } from '../../../../../../types';
+import type { NodePath } from '@babel/traverse';
 
 const files: [string, string][] = [[`/path`, '']];
 const opts: SlimFastOpts = {

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/jsx-function/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/jsx-function/index.ts
@@ -1,5 +1,3 @@
-import unique from 'array-unique';
-import { NodePath } from '@babel/traverse';
 import {
   exportDefaultDeclaration,
   functionDeclaration,
@@ -10,11 +8,14 @@ import {
   variableDeclarator,
   objectProperty,
   objectPattern,
-  Statement,
 } from '@babel/types';
+import unique from 'array-unique';
+
 import { hasAwait } from '../has-await';
 
 import type { RandomObject } from '../../../../../../types';
+import type { NodePath } from '@babel/traverse';
+import type { Statement } from '@babel/types';
 
 /**
  * Generates an exported JSX component declaration from a given AST node path and associated data.

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/normal-function/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/normal-function/index.test.ts
@@ -1,12 +1,13 @@
-import traverse, { NodePath } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { Codebase, FileContainer } from '@modular-rocks/workspace-node';
 import { describe, expect, test } from 'vitest';
 
 import { generateExportedFunction } from '.';
-import { parser } from '../../../../../visitors/utils/parser';
 import { extractIdentifiers } from '../../../../../visitors/utils/extract-identifiers';
+import { parser } from '../../../../../visitors/utils/parser';
 
 import type { SlimFastOpts } from '../../../../../../types';
+import type { NodePath } from '@babel/traverse';
 
 const files: [string, string][] = [[`/path`, '']];
 const opts: SlimFastOpts = {

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/normal-function/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/wrap/normal-function/index.ts
@@ -1,14 +1,15 @@
-import unique from 'array-unique';
-import { NodePath } from '@babel/traverse';
 import {
   exportDefaultDeclaration,
   functionDeclaration,
   blockStatement,
   returnStatement,
 } from '@babel/types';
+import unique from 'array-unique';
+
 import { hasAwait } from '../has-await';
 
 import type { RandomObject } from '../../../../../../types';
+import type { NodePath } from '@babel/traverse';
 
 /**
  * Extracts a block statement containing a return statement from the provided AST node path.

--- a/packages/slimfast-node/src/slimfast/pipeline/build/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/index.ts
@@ -1,13 +1,11 @@
-import { NodePath } from '@babel/traverse';
-
-import type { FileContainer } from '@modular-rocks/workspace-node';
-import type { SlimFast } from '@modular-rocks/slimfast';
-
 import type {
   RandomObject,
   SlimFastOpts,
   ProvisionalFile,
 } from '../../../types';
+import type { NodePath } from '@babel/traverse';
+import type { SlimFast } from '@modular-rocks/slimfast';
+import type { FileContainer } from '@modular-rocks/workspace-node';
 
 type Extract = [NodePath, RandomObject];
 

--- a/packages/slimfast-node/src/slimfast/pipeline/extract/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/extract/index.ts
@@ -1,11 +1,9 @@
-import { NodePath } from '@babel/traverse';
-import t from '@babel/types';
-
+import type { RandomObject } from '../../../types';
+import type { Visitor } from '../../visitors/visitor';
+import type { NodePath } from '@babel/traverse';
+import type t from '@babel/types';
 import type { SlimFast } from '@modular-rocks/slimfast';
 import type { FileContainer } from '@modular-rocks/workspace-node';
-
-import type { Visitor } from '../../visitors/visitor';
-import type { RandomObject } from '../../../types';
 
 type Namer = (path: NodePath, data: RandomObject, options: Option) => void;
 type Builder = (

--- a/packages/slimfast-node/src/slimfast/pipeline/name/default-function-name-generator/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/name/default-function-name-generator/index.ts
@@ -1,6 +1,5 @@
-import { NodePath } from '@babel/traverse';
-
 import type { RandomObject } from '../../../../types';
+import type { NodePath } from '@babel/traverse';
 
 /**
  * Checks if a given AST node path contains any JSX elements.

--- a/packages/slimfast-node/src/slimfast/pipeline/name/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/name/index.ts
@@ -1,10 +1,8 @@
-import t from '@babel/types';
-import { NodePath, Node } from '@babel/traverse';
-
-import type { FileContainer } from '@modular-rocks/workspace-node';
-import type { SlimFast } from '@modular-rocks/slimfast';
-
 import type { RandomObject, VisitorType } from '../../../types';
+import type { NodePath, Node } from '@babel/traverse';
+import type t from '@babel/types';
+import type { SlimFast } from '@modular-rocks/slimfast';
+import type { FileContainer } from '@modular-rocks/workspace-node';
 
 interface ProvisionalFile {
   pathname: string;

--- a/packages/slimfast-node/src/slimfast/visitors/expression/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/expression/index.test.ts
@@ -1,10 +1,10 @@
-import { NodePath } from '@babel/traverse';
 import { describe, expect, test } from 'vitest';
 
 import { ExpressionVisitor } from '.';
 import { parser } from '../utils/parser';
 
 import type { SlimFastOpts } from '../../../types';
+import type { NodePath } from '@babel/traverse';
 
 const str = JSON.stringify;
 

--- a/packages/slimfast-node/src/slimfast/visitors/expression/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/expression/index.ts
@@ -1,14 +1,13 @@
-import { Visitor } from '../visitor';
-
-import { tooSmall } from '../utils/contraints/too-small';
-import { identifiersNotWithinRange } from '../utils/contraints/identifiers-not-within-range';
-import { hasReturnStatement } from '../utils/contraints/has-return-statement';
-import { hasAssignmentExpression } from '../utils/contraints/has-assignment-expression';
 import { containsIdentifiersInOtherScopes } from '../utils/contraints/contains-identifiers-in-other-scopes';
-import { hasVariableDeclarator } from '../utils/contraints/has-variable-declarator';
+import { hasAssignmentExpression } from '../utils/contraints/has-assignment-expression';
 import { hasBlocklistedIdentifiers } from '../utils/contraints/has-blocklisted-identifiers';
-import { shouldIgnore } from '../utils/contraints/should-ignore';
+import { hasReturnStatement } from '../utils/contraints/has-return-statement';
+import { hasVariableDeclarator } from '../utils/contraints/has-variable-declarator';
+import { identifiersNotWithinRange } from '../utils/contraints/identifiers-not-within-range';
 import { removesTooMuch } from '../utils/contraints/removes-too-much';
+import { shouldIgnore } from '../utils/contraints/should-ignore';
+import { tooSmall } from '../utils/contraints/too-small';
+import { Visitor } from '../visitor';
 
 import type { RandomObject } from '../../../types';
 

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/contains-identifiers-in-other-scopes/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/contains-identifiers-in-other-scopes/index.test.ts
@@ -1,8 +1,10 @@
-import traverse, { NodePath, Node } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { describe, expect, test } from 'vitest';
 
 import { containsIdentifiersInOtherScopes } from './index';
 import { parser } from '../../parser';
+
+import type { NodePath } from '@babel/traverse';
 
 describe('Contains variables in other scopes', () => {
   test('', () => {

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/contains-identifiers-in-other-scopes/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/contains-identifiers-in-other-scopes/index.ts
@@ -1,6 +1,5 @@
-import { NodePath, Node } from '@babel/traverse';
-
 import type { RandomObject } from '../../../../../types';
+import type { NodePath, Node } from '@babel/traverse';
 
 function isInsidePath(innerPath: NodePath, outerPath: NodePath): boolean {
   let currentPath: NodePath | null = innerPath;

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-assignment-expression/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-assignment-expression/index.test.ts
@@ -1,8 +1,10 @@
-import traverse, { NodePath, Node } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { describe, expect, test } from 'vitest';
 
 import { hasAssignmentExpression } from './index';
 import { parser } from '../../parser';
+
+import type { NodePath } from '@babel/traverse';
 
 describe('Has assignment expression', () => {
   test('', () => {

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-assignment-expression/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-assignment-expression/index.ts
@@ -1,6 +1,5 @@
-import { NodePath, Node } from '@babel/traverse';
-
 import type { RandomObject } from '../../../../../types';
+import type { NodePath, Node } from '@babel/traverse';
 
 function isInsidePath(
   innerPath: NodePath,

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-blocklisted-identifiers/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-blocklisted-identifiers/index.test.ts
@@ -1,8 +1,10 @@
-import traverse, { NodePath, Node } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { describe, expect, test } from 'vitest';
 
 import { hasBlocklistedIdentifiers } from './index';
 import { parser } from '../../parser';
+
+import type { NodePath } from '@babel/traverse';
 
 describe('Has blocklisted identifiers', () => {
   test('', () => {

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-blocklisted-identifiers/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-blocklisted-identifiers/index.ts
@@ -1,7 +1,6 @@
+import type { RandomObject } from '../../../../../types';
 import type { NodePath } from '@babel/traverse';
 import type { File } from '@babel/types';
-
-import type { RandomObject } from '../../../../../types';
 
 /**
  * Generates a function to check if a given AST node path contains any identifiers that are part of a specified blocklist.

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-return-statement/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-return-statement/index.test.ts
@@ -1,8 +1,10 @@
-import traverse, { NodePath, Node } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { describe, expect, test } from 'vitest';
 
 import { hasReturnStatement } from './index';
 import { parser } from '../../parser';
+
+import type { NodePath } from '@babel/traverse';
 
 describe('Has return statement', () => {
   test('', () => {

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-return-statement/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-return-statement/index.ts
@@ -1,7 +1,7 @@
-import { NodePath, Node } from '@babel/traverse';
 import { isAFunction } from '../is-a-function';
 
 import type { RandomObject } from '../../../../../types';
+import type { NodePath, Node } from '@babel/traverse';
 
 /**
  * Determines if a given AST node path represents a return statement or contains a return statement not within a nested function.

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-variable-declarator/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-variable-declarator/index.test.ts
@@ -1,8 +1,10 @@
-import traverse, { NodePath, Node } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { describe, expect, test } from 'vitest';
 
 import { hasVariableDeclarator } from './index';
 import { parser } from '../../parser';
+
+import type { NodePath } from '@babel/traverse';
 
 describe('Has variable declarator', () => {
   test('', () => {

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-variable-declarator/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-variable-declarator/index.ts
@@ -1,6 +1,5 @@
-import { NodePath, Node } from '@babel/traverse';
-
 import type { RandomObject } from '../../../../../types';
+import type { NodePath, Node } from '@babel/traverse';
 
 /**
  * Determines if a given AST node path represents a variable declarator.

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/identifiers-not-within-range/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/identifiers-not-within-range/index.ts
@@ -1,7 +1,7 @@
-import { NodePath, Node } from '@babel/traverse';
 import { identifiersWithinRange } from '../identifiers-within-range';
 
 import type { RandomObject } from '../../../../../types';
+import type { NodePath, Node } from '@babel/traverse';
 
 /**
  * Generates a function to determine if the number of identifiers within an AST node path does not fall within a specified range.

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/identifiers-within-range/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/identifiers-within-range/index.test.ts
@@ -1,8 +1,10 @@
-import traverse, { NodePath, Node } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { describe, expect, test } from 'vitest';
 
 import { identifiersWithinRange } from './index';
 import { parser } from '../../parser';
+
+import type { NodePath } from '@babel/traverse';
 
 describe('Identifiers within range', () => {
   test('', () => {

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/identifiers-within-range/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/identifiers-within-range/index.ts
@@ -1,7 +1,7 @@
-import { NodePath, Node } from '@babel/traverse';
 import { extractIdentifiers } from '../../extract-identifiers';
 
 import type { RandomObject } from '../../../../../types';
+import type { NodePath, Node } from '@babel/traverse';
 
 /**
  * Generates a function to determine if the number of identifiers within an AST node path falls within a specified range.

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-a-function/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-a-function/index.test.ts
@@ -1,8 +1,10 @@
-import traverse, { NodePath, Node } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { describe, expect, test } from 'vitest';
 
 import { isAFunction } from './index';
 import { parser } from '../../parser';
+
+import type { NodePath } from '@babel/traverse';
 
 describe('Is a function', () => {
   test('', () => {

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-a-function/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-a-function/index.ts
@@ -1,6 +1,5 @@
-import { NodePath, Node } from '@babel/traverse';
-
 import type { RandomObject } from '../../../../../types';
+import type { NodePath, Node } from '@babel/traverse';
 
 /**
  * Determines if a given AST node path represents any kind of function.

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-call-expression/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-call-expression/index.test.ts
@@ -1,8 +1,10 @@
-import traverse, { NodePath, Node } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { describe, expect, test } from 'vitest';
 
 import { isCallExpression } from './index';
 import { parser } from '../../parser';
+
+import type { NodePath } from '@babel/traverse';
 
 describe('Is call expression', () => {
   test('', () => {

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-call-expression/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-call-expression/index.ts
@@ -1,6 +1,5 @@
-import { NodePath, Node } from '@babel/traverse';
-
 import type { RandomObject } from '../../../../../types';
+import type { NodePath, Node } from '@babel/traverse';
 
 /**
  * Determines if a given AST node path represents a call expression within an expression statement.

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/removes-too-much/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/removes-too-much/index.test.ts
@@ -1,8 +1,10 @@
-import traverse, { NodePath, Node } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { describe, expect, test } from 'vitest';
 
 import { removesTooMuch } from './index';
 import { parser } from '../../parser';
+
+import type { NodePath } from '@babel/traverse';
 
 describe('Removes too much', () => {
   const code = `() => 3 * 7`;

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/removes-too-much/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/removes-too-much/index.ts
@@ -1,6 +1,5 @@
-import { NodePath, Node } from '@babel/traverse';
-
 import type { RandomObject } from '../../../../../types';
+import type { NodePath, Node } from '@babel/traverse';
 
 const notANumber = (num: number | null | undefined): boolean =>
   num === null || num === undefined || Number.isNaN(num);

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/should-ignore/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/should-ignore/index.test.ts
@@ -1,8 +1,10 @@
-import traverse, { NodePath, Node } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { describe, expect, test } from 'vitest';
 
 import { shouldIgnore } from './index';
 import { parser } from '../../parser';
+
+import type { NodePath } from '@babel/traverse';
 
 describe('Should Ignore', () => {
   test('', () => {

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/should-ignore/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/should-ignore/index.ts
@@ -1,6 +1,7 @@
-import Traverse, { NodePath, Node } from '@babel/traverse';
+import Traverse from '@babel/traverse';
 
 import type { RandomObject } from '../../../../../types';
+import type { NodePath, Node } from '@babel/traverse';
 
 /**
  * Determines if a given AST node path contains either a `Super` or a `YieldExpression` node.

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/too-small/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/too-small/index.test.ts
@@ -1,9 +1,11 @@
-import traverse, { NodePath, Node } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { describe, expect, test } from 'vitest';
 
 import { tooSmall } from './index';
-import { parser } from '../../parser';
 import { extractIdentifiers } from '../../extract-identifiers';
+import { parser } from '../../parser';
+
+import type { NodePath } from '@babel/traverse';
 
 describe('Too Small', () => {
   const code = `let result = ((2 + 3) * 4 - Math.sqrt(9)) / (6 % 2) + Math.pow(2, 5) - parseFloat('10.5') + parseInt('100', 2);`;

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/too-small/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/too-small/index.ts
@@ -1,6 +1,5 @@
-import { NodePath, Node } from '@babel/traverse';
-
 import type { RandomObject } from '../../../../../types';
+import type { NodePath, Node } from '@babel/traverse';
 
 const notANumber = (num: number | null | undefined): boolean =>
   num === null || num === undefined || Number.isNaN(num);

--- a/packages/slimfast-node/src/slimfast/visitors/utils/extract-identifiers/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/extract-identifiers/index.test.ts
@@ -1,10 +1,11 @@
-import traverse, { NodePath, Node, Binding } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { describe, expect, test } from 'vitest';
 
 import { extractIdentifiers } from './index';
 import { parser } from '../parser';
 
 import type { RandomObject } from '../../../../types';
+import type { NodePath, Binding } from '@babel/traverse';
 
 const str = JSON.stringify;
 

--- a/packages/slimfast-node/src/slimfast/visitors/utils/extract-identifiers/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/extract-identifiers/index.ts
@@ -1,7 +1,7 @@
 import unique from 'array-unique';
-import { NodePath, Node, Binding } from '@babel/traverse';
 
 import type { RandomObject } from '../../../../types';
+import type { NodePath, Node, Binding } from '@babel/traverse';
 
 const importTypes = ['ImportDefaultSpecifier', 'ImportSpecifier'];
 const isImportStatement = (x: Binding) =>

--- a/packages/slimfast-node/src/slimfast/visitors/utils/not-in-extracted/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/not-in-extracted/index.test.ts
@@ -1,10 +1,11 @@
-import traverse, { NodePath, Node } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { describe, expect, test } from 'vitest';
 
 import { notInExtracted } from './index';
 import { parser } from '../parser';
 
 import type { RandomObject } from '../../../../types';
+import type { NodePath } from '@babel/traverse';
 
 describe('Not in extracted', () => {
   const code = `let result = ((2 + 3) * 4 - Math.sqrt(9)) / (6 % 2) + Math.pow(2, 5) - parseFloat('10.5') + parseInt('100', 2);`;

--- a/packages/slimfast-node/src/slimfast/visitors/utils/not-in-extracted/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/not-in-extracted/index.ts
@@ -1,4 +1,4 @@
-import { NodePath, Node } from '@babel/traverse';
+import type { NodePath } from '@babel/traverse';
 
 /**
  * Determines if a given Abstract Syntax Tree (AST) node or any of its parent nodes is not present in the provided `extracted` map.

--- a/packages/slimfast-node/src/slimfast/visitors/utils/reject-parents-with-types/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/reject-parents-with-types/index.test.ts
@@ -1,8 +1,10 @@
-import traverse, { NodePath, Node } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { describe, expect, test } from 'vitest';
 
 import { rejectParentsWithTypes } from './index';
 import { parser } from '../parser';
+
+import type { NodePath } from '@babel/traverse';
 
 describe('Rejected Parents with types', () => {
   const code = `let result = ((2 + 3) * 4 - Math.sqrt(9)) / (6 % 2) + Math.pow(2, 5) - parseFloat('10.5') + parseInt('100', 2);`;

--- a/packages/slimfast-node/src/slimfast/visitors/utils/reject-parents-with-types/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/reject-parents-with-types/index.ts
@@ -1,4 +1,4 @@
-import { NodePath } from '@babel/traverse';
+import type { NodePath } from '@babel/traverse';
 
 /**
  * Checks if a given AST node or any of its parent nodes are of a type specified in the `blacklistedParents` array.

--- a/packages/slimfast-node/src/slimfast/visitors/visitor/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/visitor/index.ts
@@ -1,9 +1,10 @@
-import traverse, { NodePath, Node } from '@babel/traverse';
+import traverse from '@babel/traverse';
 
-import { rejectParentsWithTypes } from '../utils/reject-parents-with-types';
 import { notInExtracted } from '../utils/not-in-extracted';
+import { rejectParentsWithTypes } from '../utils/reject-parents-with-types';
 
 import type { RandomObject } from '../../../types';
+import type { NodePath, Node } from '@babel/traverse';
 
 /**
  * The Visitor class is responsible for traversing the AST and managing extraction based on

--- a/packages/slimfast-node/src/types.ts
+++ b/packages/slimfast-node/src/types.ts
@@ -1,5 +1,5 @@
-import { CodebaseOpts } from '@modular-rocks/workspace-node/dist/types/types';
 import type { Statement } from '@babel/types';
+import type { CodebaseOpts } from '@modular-rocks/workspace-node/dist/types/types';
 
 export type RandomObject = Record<string, any>;
 

--- a/packages/slimfast/src/index.test.ts
+++ b/packages/slimfast/src/index.test.ts
@@ -1,8 +1,9 @@
-import { CodebaseOpts } from '@modular-rocks/workspace/dist/types/types';
-import { describe, expect, test, vi } from 'vitest';
 import mockFs from 'mock-fs';
+import { describe, expect, test, vi } from 'vitest';
 
 import { SlimFast } from '.';
+
+import type { CodebaseOpts } from '@modular-rocks/workspace/dist/types/types';
 
 type OutPutIteration = [number, number];
 

--- a/packages/slimfast/src/index.ts
+++ b/packages/slimfast/src/index.ts
@@ -1,5 +1,6 @@
-import type { Codebase as CodebaseType } from '@modular-rocks/workspace';
 import { Codebase, Workspace } from '@modular-rocks/workspace';
+
+import type { Codebase as CodebaseType } from '@modular-rocks/workspace';
 import type {
   CodebaseOpts,
   Options,

--- a/packages/traverse-files/src/tests/convenience.test.ts
+++ b/packages/traverse-files/src/tests/convenience.test.ts
@@ -1,7 +1,6 @@
 import { posix } from 'path';
 
 import mockFs from 'mock-fs';
-
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import {

--- a/packages/workspace-node/src/workspace/codebase/file/index.test.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/index.test.ts
@@ -6,9 +6,9 @@ import {
 } from '@babel/types';
 import { describe, expect, test } from 'vitest';
 
+import { FileContainer } from '.';
 import { Codebase } from '..';
 
-import { FileContainer } from '.';
 import type { CodebaseOpts } from '../../../types';
 
 const str = JSON.stringify;

--- a/packages/workspace-node/src/workspace/codebase/file/index.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/index.ts
@@ -1,11 +1,11 @@
 import { FileContainer as FileContainerBase } from '@modular-rocks/workspace';
 
-import type { File, Statement } from '@babel/types';
-
-import { Codebase } from '..';
 import { parse } from './parse';
 import { print } from './print';
 import { tooSimple } from './too-simple';
+
+import type { Codebase } from '..';
+import type { File, Statement } from '@babel/types';
 
 type EndOfLine = '\r\n' | '\n' | '\r';
 

--- a/packages/workspace-node/src/workspace/codebase/file/parse/index.test.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/parse/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest';
+
 import { parse } from '.';
 
 describe('"parse" utility function', () => {

--- a/packages/workspace-node/src/workspace/codebase/file/parse/index.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/parse/index.ts
@@ -1,5 +1,6 @@
-import type { ParserOptions } from '@babel/parser';
 import { parse as babelParser } from '@babel/parser';
+
+import type { ParserOptions } from '@babel/parser';
 
 const babelConfig: ParserOptions = {
   sourceType: 'module',

--- a/packages/workspace-node/src/workspace/codebase/file/print/index.test.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/print/index.test.ts
@@ -1,8 +1,9 @@
-import type { Options } from 'recast';
-
 import { describe, expect, test } from 'vitest';
+
 import { print } from '.';
 import { parse } from '../parse';
+
+import type { Options } from 'recast';
 
 describe('"print" utility function', () => {
   test('should return an object with the specified properties', () => {

--- a/packages/workspace-node/src/workspace/codebase/file/print/index.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/print/index.ts
@@ -1,5 +1,6 @@
-import type { Options, types } from 'recast';
 import { print as recastPrinter } from 'recast';
+
+import type { Options, types } from 'recast';
 
 /**
  * Prints the given AST node using the provided options.

--- a/packages/workspace-node/src/workspace/codebase/file/too-simple/index.test.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/too-simple/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest';
+
 import { measure, tooSimple } from '.';
 
 describe('"measure" utility function', () => {

--- a/packages/workspace-node/src/workspace/codebase/file/too-simple/index.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/too-simple/index.ts
@@ -1,9 +1,10 @@
-import { File } from '@babel/types';
 import {
   loc,
   maintainability,
   totalCyclomaticComplexity,
 } from '@modular-rocks/metrics-ts-js';
+
+import type { File } from '@babel/types';
 
 type MetricOpts = {
   code?: string;

--- a/packages/workspace-node/src/workspace/codebase/index.test.ts
+++ b/packages/workspace-node/src/workspace/codebase/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 
 import { Codebase } from '.';
 
-import { CodebaseOpts } from '../../types';
+import type { CodebaseOpts } from '../../types';
 
 const str = JSON.stringify;
 

--- a/packages/workspace/src/workspace/codebase/index.ts
+++ b/packages/workspace/src/workspace/codebase/index.ts
@@ -1,12 +1,12 @@
 import { basename, dirname } from 'path';
 
 import { copy } from './copy';
-import type { FileContainer as FileContainerType } from './file';
 import { FileContainer } from './file';
 import { makeDirectory } from './make-directory';
 import { fromFile, saveFile, saveToJSON } from './save';
 import { storeDependencies } from './store-dependencies';
 
+import type { FileContainer as FileContainerType } from './file';
 import type {
   CodebaseOpts,
   FilesContainer,

--- a/packages/workspace/src/workspace/codebase/make-directory/index.test.ts
+++ b/packages/workspace/src/workspace/codebase/make-directory/index.test.ts
@@ -1,4 +1,5 @@
 import { normalize } from 'path';
+
 import { describe, expect, test } from 'vitest';
 
 import { makeDirectory } from '.';

--- a/packages/workspace/src/workspace/codebase/save/index.test.ts
+++ b/packages/workspace/src/workspace/codebase/save/index.test.ts
@@ -3,8 +3,6 @@ import { readFileSync, writeFileSync } from 'fs';
 import mockFs from 'mock-fs';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { Codebase } from '..';
-import type { CodebaseOpts, RandomObject } from '../../../types';
 import {
   createDir,
   fromFile,
@@ -13,6 +11,9 @@ import {
   toFile,
   toJson,
 } from './index';
+import { Codebase } from '..';
+
+import type { CodebaseOpts, RandomObject } from '../../../types';
 
 describe('Save utilities', () => {
   const mockData: RandomObject = {

--- a/packages/workspace/src/workspace/codebase/save/index.ts
+++ b/packages/workspace/src/workspace/codebase/save/index.ts
@@ -23,6 +23,7 @@ export const createDir = async (pathname: string, contents: string) => {
     await mkdir(folder, { recursive: true });
     await writeFile(pathname, contents);
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.error(err);
   }
 };
@@ -93,6 +94,7 @@ export const fromFile = async (pathname: string, codebase: Codebase) => {
     const jsonData: Record<string, unknown> = JSON.parse(data);
     codebase.fromJson(jsonData);
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('Could not parse data:', error);
   }
 };

--- a/packages/workspace/src/workspace/index.ts
+++ b/packages/workspace/src/workspace/index.ts
@@ -1,8 +1,9 @@
 import { readDirectory } from '@modular-rocks/traverse-files';
+
 import { pipeline as runPipeline } from './pipeline';
 
-import type { WorkspaceOpts } from '../types';
 import type { FileContainer } from './codebase/file';
+import type { WorkspaceOpts } from '../types';
 
 export class Workspace {
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.28.1
         version: 2.28.1(@typescript-eslint/parser@6.4.0)(eslint@8.47.0)
-      eslint-plugin-prettier:
-        specifier: 5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3)
+      eslint-plugin-unused-imports:
+        specifier: 3.0.0
+        version: 3.0.0(@typescript-eslint/eslint-plugin@6.4.0)(eslint@8.47.0)
 
   config/tsconfig: {}
 
@@ -2048,18 +2048,6 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  /@pkgr/utils@2.4.2:
-    resolution: {integrity: sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
-    dependencies:
-      cross-spawn: 7.0.3
-      fast-glob: 3.3.1
-      is-glob: 4.0.3
-      open: 9.1.0
-      picocolors: 1.0.0
-      tslib: 2.6.2
-    dev: false
-
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
@@ -2552,18 +2540,6 @@ packages:
       is-windows: 1.0.2
     dev: true
 
-  /big-integer@1.6.51:
-    resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
-    engines: {node: '>=0.6'}
-    dev: false
-
-  /bplist-parser@0.2.0:
-    resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
-    engines: {node: '>= 5.10.0'}
-    dependencies:
-      big-integer: 1.6.51
-    dev: false
-
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
@@ -2591,13 +2567,6 @@ packages:
       electron-to-chromium: 1.4.496
       node-releases: 2.0.13
       update-browserslist-db: 1.0.11(browserslist@4.21.10)
-    dev: false
-
-  /bundle-name@3.0.0:
-    resolution: {integrity: sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==}
-    engines: {node: '>=12'}
-    dependencies:
-      run-applescript: 5.0.0
     dev: false
 
   /cac@6.7.14:
@@ -2826,24 +2795,6 @@ packages:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: false
 
-  /default-browser-id@3.0.0:
-    resolution: {integrity: sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==}
-    engines: {node: '>=12'}
-    dependencies:
-      bplist-parser: 0.2.0
-      untildify: 4.0.0
-    dev: false
-
-  /default-browser@4.0.0:
-    resolution: {integrity: sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==}
-    engines: {node: '>=14.16'}
-    dependencies:
-      bundle-name: 3.0.0
-      default-browser-id: 3.0.0
-      execa: 7.2.0
-      titleize: 3.0.0
-    dev: false
-
   /defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
     dependencies:
@@ -2858,11 +2809,6 @@ packages:
       gopd: 1.0.1
       has-property-descriptors: 1.0.0
     dev: true
-
-  /define-lazy-prop@3.0.0:
-    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
-    engines: {node: '>=12'}
-    dev: false
 
   /define-properties@1.2.0:
     resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
@@ -3208,25 +3154,24 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-prettier@5.0.0(eslint-config-prettier@9.0.0)(eslint@8.47.0)(prettier@3.0.3):
-    resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  /eslint-plugin-unused-imports@3.0.0(@typescript-eslint/eslint-plugin@6.4.0)(eslint@8.47.0):
+    resolution: {integrity: sha512-sduiswLJfZHeeBJ+MQaG+xYzSWdRXoSw61DpU13mzWumCkR0ufD0HmO4kdNokjrkluMHpj/7PJeN35pgbhW3kw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
-      eslint: '>=8.0.0'
-      eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
+      '@typescript-eslint/eslint-plugin': ^6.0.0
+      eslint: ^8.0.0
     peerDependenciesMeta:
-      '@types/eslint':
-        optional: true
-      eslint-config-prettier:
+      '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
+      '@typescript-eslint/eslint-plugin': 6.4.0(@typescript-eslint/parser@6.4.0)(eslint@8.47.0)(typescript@5.2.2)
       eslint: 8.47.0
-      eslint-config-prettier: 9.0.0(eslint@8.47.0)
-      prettier: 3.0.3
-      prettier-linter-helpers: 1.0.0
-      synckit: 0.8.5
+      eslint-rule-composer: 0.3.0
+    dev: false
+
+  /eslint-rule-composer@0.3.0:
+    resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==}
+    engines: {node: '>=4.0.0'}
     dev: false
 
   /eslint-scope@7.2.2:
@@ -3326,36 +3271,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /execa@5.1.1:
-    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
-    engines: {node: '>=10'}
-    dependencies:
-      cross-spawn: 7.0.3
-      get-stream: 6.0.1
-      human-signals: 2.1.0
-      is-stream: 2.0.1
-      merge-stream: 2.0.0
-      npm-run-path: 4.0.1
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-      strip-final-newline: 2.0.0
-    dev: false
-
-  /execa@7.2.0:
-    resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
-    engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
-    dependencies:
-      cross-spawn: 7.0.3
-      get-stream: 6.0.1
-      human-signals: 4.3.1
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.1.0
-      onetime: 6.0.0
-      signal-exit: 3.0.7
-      strip-final-newline: 3.0.0
-    dev: false
-
   /extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
     dev: true
@@ -3371,10 +3286,6 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: false
-
-  /fast-diff@1.3.0:
-    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
     dev: false
 
   /fast-glob@3.3.1:
@@ -3529,11 +3440,6 @@ packages:
       has-proto: 1.0.1
       has-symbols: 1.0.3
 
-  /get-stream@6.0.1:
-    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
-    engines: {node: '>=10'}
-    dev: false
-
   /get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
     engines: {node: '>= 0.4'}
@@ -3668,16 +3574,6 @@ packages:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
     dev: true
 
-  /human-signals@2.1.0:
-    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
-    engines: {node: '>=10.17.0'}
-    dev: false
-
-  /human-signals@4.3.1:
-    resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
-    engines: {node: '>=14.18.0'}
-    dev: false
-
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -3777,18 +3673,6 @@ packages:
     dependencies:
       has-tostringtag: 1.0.0
 
-  /is-docker@2.2.1:
-    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
-    engines: {node: '>=8'}
-    hasBin: true
-    dev: false
-
-  /is-docker@3.0.0:
-    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    hasBin: true
-    dev: false
-
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -3810,14 +3694,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
-
-  /is-inside-container@1.0.0:
-    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
-    engines: {node: '>=14.16'}
-    hasBin: true
-    dependencies:
-      is-docker: 3.0.0
-    dev: false
 
   /is-nan@1.3.2:
     resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
@@ -3863,16 +3739,6 @@ packages:
     dependencies:
       call-bind: 1.0.2
 
-  /is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
-    dev: false
-
-  /is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: false
-
   /is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
@@ -3907,13 +3773,6 @@ packages:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /is-wsl@2.2.0:
-    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
-    engines: {node: '>=8'}
-    dependencies:
-      is-docker: 2.2.1
-    dev: false
 
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -4146,10 +4005,6 @@ packages:
       yargs-parser: 18.1.3
     dev: true
 
-  /merge-stream@2.0.0:
-    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
-    dev: false
-
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -4160,16 +4015,6 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
-
-  /mimic-fn@2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
-    engines: {node: '>=6'}
-    dev: false
-
-  /mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
-    dev: false
 
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -4255,20 +4100,6 @@ packages:
       validate-npm-package-license: 3.0.4
     dev: true
 
-  /npm-run-path@4.0.1:
-    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
-    engines: {node: '>=8'}
-    dependencies:
-      path-key: 3.1.1
-    dev: false
-
-  /npm-run-path@5.1.0:
-    resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      path-key: 4.0.0
-    dev: false
-
   /object-inspect@1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
 
@@ -4333,30 +4164,6 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
-
-  /onetime@5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
-    engines: {node: '>=6'}
-    dependencies:
-      mimic-fn: 2.1.0
-    dev: false
-
-  /onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      mimic-fn: 4.0.0
-    dev: false
-
-  /open@9.1.0:
-    resolution: {integrity: sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==}
-    engines: {node: '>=14.16'}
-    dependencies:
-      default-browser: 4.0.0
-      define-lazy-prop: 3.0.0
-      is-inside-container: 1.0.0
-      is-wsl: 2.2.0
-    dev: false
 
   /optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
@@ -4459,11 +4266,6 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
-    dev: false
-
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -4530,13 +4332,6 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: false
 
-  /prettier-linter-helpers@1.0.0:
-    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      fast-diff: 1.3.0
-    dev: false
-
   /prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -4547,6 +4342,7 @@ packages:
     resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
     engines: {node: '>=14'}
     hasBin: true
+    dev: true
 
   /pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
@@ -4739,13 +4535,6 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /run-applescript@5.0.0:
-    resolution: {integrity: sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==}
-    engines: {node: '>=12'}
-    dependencies:
-      execa: 5.1.1
-    dev: false
-
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -4849,6 +4638,7 @@ packages:
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+    dev: true
 
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -4992,16 +4782,6 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
-  /strip-final-newline@2.0.0:
-    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
-    engines: {node: '>=6'}
-    dev: false
-
-  /strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
-    engines: {node: '>=12'}
-    dev: false
-
   /strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
@@ -5036,14 +4816,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  /synckit@0.8.5:
-    resolution: {integrity: sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    dependencies:
-      '@pkgr/utils': 2.4.2
-      tslib: 2.6.2
-    dev: false
-
   /term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -5075,11 +4847,6 @@ packages:
     resolution: {integrity: sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==}
     engines: {node: '>=14.0.0'}
     dev: true
-
-  /titleize@3.0.0:
-    resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
-    engines: {node: '>=12'}
-    dev: false
 
   /tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -5313,11 +5080,6 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
     dev: true
-
-  /untildify@4.0.0:
-    resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
-    engines: {node: '>=8'}
-    dev: false
 
   /update-browserslist-db@1.0.11(browserslist@4.21.10):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}


### PR DESCRIPTION
This PR refactors the imports across all packages to improve clarity and maintainability. Changes include: 
- Grouping imports with a new line in between different groups.
- Ensuring imports are alphabetized.
- Requiring the use of "type" for imports where appropriate.

Also, Prettier has been removed from ESLint, so it won't show errors on the IDE. Now Prettier will be checked with Prettier's built-in "check" command with `pnpm check:format`.