### PR TITLE
[slimfast-node]: Refactor `isAFunction` and add tests

### DIFF
--- a/.changeset/small-bears-obey.md
+++ b/.changeset/small-bears-obey.md
@@ -1,0 +1,5 @@
+---
+"@modular-rocks/slimfast-node": patch
+---
+
+Refactor `isAFunction` and add tests

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-a-function/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-a-function/index.test.ts
@@ -6,37 +6,158 @@ import { parser } from '../../parser';
 
 import type { NodePath } from '@babel/traverse';
 
-describe('Is a function', () => {
-  test('', () => {
+describe('"isAFunction" utility function', () => {
+  test('should identify an arrow function expression as a function', () => {
     const code = '() => 3 * 7';
     const ast = parser(code);
     let rootPath: NodePath | null = null;
 
     traverse(ast, {
-      ArrayExpression(path) {
+      ArrowFunctionExpression(path) {
         rootPath = path;
         path.stop();
       },
     });
+
+    let result = false;
     if (rootPath !== null) {
-      const result = isAFunction(rootPath);
-      expect(result).toBe(true);
+      result = isAFunction(rootPath);
     }
+    expect(
+      result,
+      'Expected an arrow function expression to be identified as a function'
+    ).toBe(true);
   });
-  test('', () => {
+
+  test('should identify a function declaration as a function', () => {
+    const code = 'function foo() {}';
+    const ast = parser(code);
+    let rootPath: NodePath | null = null;
+
+    traverse(ast, {
+      FunctionDeclaration(path) {
+        rootPath = path;
+        path.stop();
+      },
+    });
+
+    let result = false;
+    if (rootPath !== null) {
+      result = isAFunction(rootPath);
+    }
+    expect(
+      result,
+      'Expected a function declaration to be identified as a function'
+    ).toBe(true);
+  });
+
+  test('should identify a function expression as a function', () => {
+    const code = 'const foo = function() {}';
+    const ast = parser(code);
+    let rootPath: NodePath | null = null;
+
+    traverse(ast, {
+      FunctionExpression(path) {
+        rootPath = path;
+        path.stop();
+      },
+    });
+
+    let result = false;
+    if (rootPath !== null) {
+      result = isAFunction(rootPath);
+    }
+    expect(
+      result,
+      'Expected a function expression to be identified as a function'
+    ).toBe(true);
+  });
+
+  test('should identify an object method as a function', () => {
+    const code = 'const obj = { method() {} }';
+    const ast = parser(code);
+    let rootPath: NodePath | null = null;
+
+    traverse(ast, {
+      ObjectMethod(path) {
+        rootPath = path;
+        path.stop();
+      },
+    });
+
+    let result = false;
+    if (rootPath !== null) {
+      result = isAFunction(rootPath);
+    }
+    expect(
+      result,
+      'Expected an object method to be identified as a function'
+    ).toBe(true);
+  });
+
+  test('should identify a class method as a function', () => {
+    const code = 'class MyClass { method() {} }';
+    const ast = parser(code);
+    let rootPath: NodePath | null = null;
+
+    traverse(ast, {
+      ClassMethod(path) {
+        rootPath = path;
+        path.stop();
+      },
+    });
+
+    let result = false;
+    if (rootPath !== null) {
+      result = isAFunction(rootPath);
+    }
+    expect(
+      result,
+      'Expected a class method to be identified as a function'
+    ).toBe(true);
+  });
+
+  test('should identify a private class method as a function', () => {
+    const code = 'class MyClass { #privateMethod() {} }';
+    const ast = parser(code);
+    let rootPath: NodePath | null = null;
+
+    traverse(ast, {
+      ClassPrivateMethod(path) {
+        rootPath = path;
+        path.stop();
+      },
+    });
+
+    let result = false;
+    if (rootPath !== null) {
+      result = isAFunction(rootPath);
+    }
+    expect(
+      result,
+      'Expected a private class method to be identified as a function'
+    ).toBe(true);
+  });
+
+  test('should not identify a non-function expression as a function', () => {
     const code = '3 * 7';
     const ast = parser(code);
     let rootPath: NodePath | null = null;
 
     traverse(ast, {
-      ArrayExpression(path) {
+      ExpressionStatement(path) {
         rootPath = path;
         path.stop();
       },
     });
+
+    let result = false;
     if (rootPath !== null) {
-      const result = isAFunction(rootPath);
-      expect(result).toBe(false);
+      result = isAFunction(rootPath);
     }
+    expect(
+      result,
+      'Expected a non-function expression to not be identified as a function'
+    ).toBe(false);
   });
 });

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-a-function/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/is-a-function/index.ts
@@ -15,13 +15,4 @@ import type { Constraint } from '../../../../../types';
  *   // Handle the function node.
  * }
  */
-export const isAFunction: Constraint = (path) => {
-  return [
-    'FunctionDeclaration',
-    'FunctionExpression',
-    'ArrowFunctionExpression',
-    'ObjectMethod',
-    'ClassMethod',
-    'PrivateMethod',
-  ].includes(path.type);
-};
+export const isAFunction: Constraint = (path) => path.isFunction();


### PR DESCRIPTION
This PR refactors the `isAFunction` utility function within the `slimfast-node` package. The function now directly uses `path.isFunction()`. Additionally, tests have been added.

The changes include:
- Simplified the `isAFunction` implementation by using `path.isFunction()`.
- Added tests for:
  - Arrow functions
  - Function declarations
  - Function expressions
  - Object methods
  - Class methods
  - Private class methods
  - Non-function expressions
