### PR TITLE
chore: Update export paths in package.json for better IntelliSense

### DIFF
--- a/.changeset/serious-dryers-sneeze.md
+++ b/.changeset/serious-dryers-sneeze.md
@@ -1,0 +1,10 @@
+---
+"@modular-rocks/traverse-files": patch
+"@modular-rocks/workspace-node": patch
+"@modular-rocks/slimfast-node": patch
+"@modular-rocks/workspace": patch
+"@modular-rocks/slimfast": patch
+"tsconfig": patch
+---
+
+Chore: Updated export paths in `package.json` for better IntelliSense and modified `tsconfig.json`

--- a/config/tsconfig/tsconfig.json
+++ b/config/tsconfig/tsconfig.json
@@ -2,13 +2,18 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "exclude": ["node_modules"],
   "compilerOptions": {
-    "target": "es2020",
-    "module": "commonjs",
+    "target": "ESNext",
+    "module": "ESNext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
     "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
     "types": ["vitest"]
   }
 }

--- a/packages/slimfast-node/package.json
+++ b/packages/slimfast-node/package.json
@@ -6,39 +6,39 @@
   "exports": {
     ".": {
       "default": "./dist/index.js",
-      "types": "./dist/types/index.d.ts"
+      "types": "./dis/index.d.ts"
     },
     "./utils": {
       "default": "./dist/exports/utils/index.js",
-      "types": "./dist/types/exports/utils/index.d.ts"
+      "types": "./dis/exports/utils/index.d.ts"
     },
-    "./utils/pipeline": {
+    "./pipeline": {
       "default": "./dist/exports/pipeline/index.js",
-      "types": "./dist/types/exports/pipeline/index.d.ts"
+      "types": "./dis/exports/pipeline/index.d.ts"
     },
-    "./utils/generator": {
+    "./generator": {
       "default": "./dist/exports/generator/index.js",
-      "types": "./dist/types/exports/generator/index.d.ts"
+      "types": "./dis/exports/generator/index.d.ts"
     },
-    "./utils/constraints": {
+    "./constraints": {
       "default": "./dist/exports/constraints/index.js",
-      "types": "./dist/types/exports/constraints/index.d.ts"
-    },
-    "./utils/visitors": {
-      "default": "./dist/exports/utils/visitors/index.js",
-      "types": "./dist/types/exports/utils/visitors/index.d.ts"
+      "types": "./dis/exports/constraints/index.d.ts"
     },
     "./visitors": {
       "default": "./dist/exports/visitors/index.js",
-      "types": "./dist/types/exports/visitors/index.d.ts"
+      "types": "./dis/exports/visitors/index.d.ts"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "default": "./dist/types.js"
     },
     "./package.json": "./package.json"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dis/index.d.ts",
   "engines": {
     "node": ">=20.0.0"
   },
-  "files": ["dist"],
+  "files": ["dist", "src/**/*.ts", "!src/**/*.test.ts"],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "build:w": "tsc -p tsconfig.json -w",

--- a/packages/slimfast-node/src/exports/utils/visitors/index.ts
+++ b/packages/slimfast-node/src/exports/utils/visitors/index.ts
@@ -1,4 +1,0 @@
-export { extractIdentifiers } from '../../../slimfast/visitors/utils/extract-identifiers';
-export { notInExtracted } from '../../../slimfast/visitors/utils/not-in-extracted';
-export { parser } from '../../../slimfast/visitors/utils/parser';
-export { rejectParentsWithTypes } from '../../../slimfast/visitors/utils/reject-parents-with-types';

--- a/packages/slimfast-node/src/exports/visitors/index.ts
+++ b/packages/slimfast-node/src/exports/visitors/index.ts
@@ -1,2 +1,6 @@
 export { ExpressionVisitor } from '../../slimfast/visitors/expression';
 export { Visitor } from '../../slimfast/visitors/visitor';
+export { extractIdentifiers } from '../../slimfast/visitors/utils/extract-identifiers';
+export { notInExtracted } from '../../slimfast/visitors/utils/not-in-extracted';
+export { parser } from '../../slimfast/visitors/utils/parser';
+export { rejectParentsWithTypes } from '../../slimfast/visitors/utils/reject-parents-with-types';

--- a/packages/slimfast-node/src/slimfast/pipeline/build/builder/combine-imports/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/build/builder/combine-imports/index.test.ts
@@ -10,7 +10,7 @@ import { parser } from '../../../../visitors/utils/parser';
 
 import type { ConstraintData } from '../../../../../types';
 import type { NodePath } from '@babel/traverse';
-import type { CodebaseOpts } from '@modular-rocks/workspace-node/dist/types/types';
+import type { CodebaseOpts } from '@modular-rocks/workspace-node/types';
 
 const files: [string, string][] = [['/path', '']];
 const opts: CodebaseOpts = {

--- a/packages/slimfast-node/src/types.ts
+++ b/packages/slimfast-node/src/types.ts
@@ -3,7 +3,7 @@ import type { NamerGenerator } from './slimfast/pipeline/name/default-function-n
 import type { ExpressionVisitor } from './slimfast/visitors/expression';
 import type { Binding, NodePath } from '@babel/traverse';
 import type { Node, Statement } from '@babel/types';
-import type { CodebaseOpts } from '@modular-rocks/workspace-node/dist/types/types';
+import type { CodebaseOpts } from '@modular-rocks/workspace-node/types';
 
 export type RandomObject = Record<string, any>;
 

--- a/packages/slimfast-node/tsconfig.json
+++ b/packages/slimfast-node/tsconfig.json
@@ -2,8 +2,6 @@
   "include": ["src"],
   "extends": "tsconfig/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2018",
-    "outDir": "dist",
-    "declarationDir": "dist/types"
+    "outDir": "dist"
   }
 }

--- a/packages/slimfast/package.json
+++ b/packages/slimfast/package.json
@@ -6,15 +6,19 @@
   "exports": {
     ".": {
       "default": "./dist/index.js",
-      "types": "./dist/types/index.d.ts"
+      "types": "./dist/index.d.ts"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "default": "./dist/types.js"
     },
     "./package.json": "./package.json"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "engines": {
     "node": ">=20.0.0"
   },
-  "files": ["dist"],
+  "files": ["dist", "src/**/*.ts", "!src/**/*.test.ts"],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "build:w": "tsc -p tsconfig.json -w",

--- a/packages/slimfast/src/index.test.ts
+++ b/packages/slimfast/src/index.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test, vi } from 'vitest';
 
 import { SlimFast } from '.';
 
-import type { CodebaseOpts } from '@modular-rocks/workspace/dist/types/types';
+import type { CodebaseOpts } from '@modular-rocks/workspace/types';
 
 type OutPutIteration = [number, number];
 

--- a/packages/slimfast/src/index.ts
+++ b/packages/slimfast/src/index.ts
@@ -1,10 +1,7 @@
 import { Codebase, Workspace } from '@modular-rocks/workspace';
 
 import type { Codebase as CodebaseType } from '@modular-rocks/workspace';
-import type {
-  CodebaseOpts,
-  Options,
-} from '@modular-rocks/workspace/dist/types/types';
+import type { CodebaseOpts, Options } from '@modular-rocks/workspace/types';
 
 /**
  * The SlimFast class extends the Workspace class and represents a workspace that

--- a/packages/slimfast/tsconfig.json
+++ b/packages/slimfast/tsconfig.json
@@ -2,8 +2,6 @@
   "include": ["src"],
   "extends": "tsconfig/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2018",
-    "outDir": "dist",
-    "declarationDir": "dist/types"
+    "outDir": "dist"
   }
 }

--- a/packages/traverse-files/package.json
+++ b/packages/traverse-files/package.json
@@ -5,20 +5,24 @@
   "main": "./dist/index.js",
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
+      "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
     "./convenience": {
-      "types": "./dist/types/convenience.d.ts",
+      "types": "./dist/convenience.d.ts",
       "default": "./dist/convenience.js"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "default": "./dist/types.js"
     },
     "./package.json": "./package.json"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "engines": {
     "node": ">=20.0.0"
   },
-  "files": ["dist"],
+  "files": ["dist", "!dist/tests/**/*", "src/**/*.ts", "!src/**/*.test.ts"],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "build:w": "tsc -p tsconfig.json -w",

--- a/packages/traverse-files/tsconfig.json
+++ b/packages/traverse-files/tsconfig.json
@@ -2,7 +2,6 @@
   "include": ["src"],
   "extends": "tsconfig/tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "declarationDir": "dist/types"
+    "outDir": "./dist"
   }
 }

--- a/packages/workspace-node/package.json
+++ b/packages/workspace-node/package.json
@@ -6,15 +6,19 @@
   "exports": {
     ".": {
       "default": "./dist/index.js",
-      "types": "./dist/types/index.d.ts"
+      "types": "./dist/index.d.ts"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "default": "./dist/types.js"
     },
     "./package.json": "./package.json"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "engines": {
     "node": ">=20.0.0"
   },
-  "files": ["dist"],
+  "files": ["dist", "src/**/*.ts", "!src/**/*.test.ts"],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "build:w": "tsc -p tsconfig.json -w",

--- a/packages/workspace-node/src/types.ts
+++ b/packages/workspace-node/src/types.ts
@@ -1,4 +1,4 @@
 export type {
   CodebaseOpts,
   WorkspaceOpts,
-} from '@modular-rocks/workspace/dist/types/types';
+} from '@modular-rocks/workspace/types';

--- a/packages/workspace-node/src/workspace/codebase/file/index.ts
+++ b/packages/workspace-node/src/workspace/codebase/file/index.ts
@@ -10,7 +10,8 @@ import type { File, Statement } from '@babel/types';
 type EndOfLine = '\r\n' | '\n' | '\r';
 
 export class FileContainer extends FileContainerBase {
-  ast?: File;
+  // TODO: Fix type on @modular-rocks/workspace
+  // ast?: File;
 
   constructor(path: string, code: string, codebase: Codebase) {
     super(path, code, codebase);

--- a/packages/workspace-node/tsconfig.json
+++ b/packages/workspace-node/tsconfig.json
@@ -2,8 +2,6 @@
   "include": ["src"],
   "extends": "tsconfig/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2018",
-    "outDir": "dist",
-    "declarationDir": "dist/types"
+    "outDir": "dist"
   }
 }

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -6,15 +6,19 @@
   "exports": {
     ".": {
       "default": "./dist/index.js",
-      "types": "./dist/types/index.d.ts"
+      "types": "./dist/index.d.ts"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "default": "./dist/types.js"
     },
     "./package.json": "./package.json"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "engines": {
     "node": ">=20.0.0"
   },
-  "files": ["dist"],
+  "files": ["dist", "src/**/*.ts", "!src/**/*.test.ts"],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "build:w": "tsc -p tsconfig.json -w",

--- a/packages/workspace/tsconfig.json
+++ b/packages/workspace/tsconfig.json
@@ -2,8 +2,6 @@
   "include": ["src"],
   "extends": "tsconfig/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2018",
-    "outDir": "dist",
-    "declarationDir": "dist/types"
+    "outDir": "./dist"
   }
 }


### PR DESCRIPTION
This PR includes updates to the export paths in the `package.json` files and modifications to the `tsconfig.json` files of the packages to improve IntelliSense and `Go to Definition` in vscode.