### PR TITLE
[slimfast-node]: Fix hasReturnStatement to check path parent

### DIFF
--- a/.changeset/early-apples-sell.md
+++ b/.changeset/early-apples-sell.md
@@ -1,0 +1,5 @@
+---
+"@modular-rocks/slimfast-node": patch
+---
+
+Fix: The `hasReturnStatement` constraint will now correctly check the path parent.

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-return-statement/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-return-statement/index.test.ts
@@ -6,7 +6,7 @@ import { parser } from '../../parser';
 
 import type { NodePath } from '@babel/traverse';
 
-describe('Is problematic', () => {
+describe('"hasReturnStatement" constraint function', () => {
   test('wrapped in arrow function', () => {
     const code = `() => {
       return yes;
@@ -55,7 +55,7 @@ describe('Is problematic', () => {
     expect(result).toBe(false);
   });
 
-  test('in return stament expression', () => {
+  test('in return statement expression', () => {
     const code = `function foo() {
       return yes;
     }`;
@@ -79,7 +79,7 @@ describe('Is problematic', () => {
     expect(result).toBe(true);
   });
 
-  test('in return statement expression', () => {
+  test('in block statement expression', () => {
     const code = `function foo() {
       return yes;
     }`;
@@ -88,7 +88,7 @@ describe('Is problematic', () => {
     let rootPath: NodePath | null = null;
 
     traverse(ast, {
-      // starting from the BlockStatement so the return statement is not wrapped into a fu
+      // starting from the BlockStatement so the return statement is not wrapped into a function
       BlockStatement(path) {
         rootPath = path;
         path.stop();
@@ -105,7 +105,7 @@ describe('Is problematic', () => {
 });
 
 describe('Has no return statement', () => {
-  test('in a random expression', () => {
+  test('in a simple expression', () => {
     const code = 'yes;';
 
     const ast = parser(code);
@@ -124,5 +124,77 @@ describe('Has no return statement', () => {
     }
 
     expect(result).toBe(false);
+  });
+});
+
+describe('Problematic return statements', () => {
+  const snippets = [
+    'function foo () { return 42; }',
+    'function foo () { if (true) { return "Hello"; } }',
+    'function foo () { for (let i = 0; i < 10; i++) { return i; } }',
+    'function foo () { let i = 0; while (i < 5) { return i; i++; } }',
+    'function foo () { let j = 0; do { return j; j++; } while (j < 3); }',
+    'function foo () { switch (x) { case 1: return "one"; case 2: return "two"; } }',
+    'function foo () { try { return "Trying"; } catch (e) { console.log(e); } }',
+    'function foo () { try { throw new Error("Oops"); } catch (e) { return "Caught"; } }',
+    'function foo () { try { /* some code */ } finally { return "Finally"; } }',
+    'function foo () { label: { return "Label"; } }',
+  ];
+
+  snippets.forEach((code, index) => {
+    test(`snippet ${index + 1} is problematic`, () => {
+      const ast = parser(code);
+      let rootPath: NodePath | null = null;
+
+      traverse(ast, {
+        BlockStatement(path) {
+          rootPath = path;
+          path.stop();
+        },
+      });
+      let result = false;
+
+      if (rootPath !== null) {
+        result = hasReturnStatement(rootPath);
+      }
+
+      expect(result, code).toBe(true);
+    });
+  });
+});
+
+describe('Non-problematic return statements', () => {
+  const snippets = [
+    'function test() { const result = true ? (() => { return 1; })() : 2; }',
+    'function test() { const result = true && (() => { return 3; })(); }',
+    'function test() { const result = false || (() => { return 4; })(); }',
+    'function test() { const result = !(() => { return 5; })(); }',
+    'function test() { const result = (1, (() => { return 6; })()); }',
+    'function test() { const result = (x = (() => { return 7; })()); }',
+    'function test() { const arr = [(() => { return 8; })()]; }',
+    'function test() { const obj = { key: (() => { return 9; })() }; }',
+    'function test() { const result = `${(() => { return 10; })()}`; }',
+    'function test() { const result = tag`${(() => { return 11; })()}`; }',
+  ];
+
+  snippets.forEach((code, index) => {
+    test(`snippet ${index + 1} is not problematic`, () => {
+      const ast = parser(code);
+      let rootPath: NodePath | null = null;
+
+      traverse(ast, {
+        enter(path) {
+          rootPath = path;
+          path.stop();
+        },
+      });
+      let result = true;
+
+      if (rootPath !== null) {
+        result = hasReturnStatement(rootPath);
+      }
+
+      expect(result, code).toBe(false);
+    });
   });
 });

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-return-statement/index.test.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-return-statement/index.test.ts
@@ -6,40 +6,123 @@ import { parser } from '../../parser';
 
 import type { NodePath } from '@babel/traverse';
 
-describe('Has return statement', () => {
-  test('', () => {
+describe('Is problematic', () => {
+  test('wrapped in arrow function', () => {
     const code = `() => {
       return yes;
     }`;
+
     const ast = parser(code);
     let rootPath: NodePath | null = null;
 
     traverse(ast, {
-      ArrayExpression(path) {
+      // starting from the arrow function declaration so the return statement is wrapped into a function
+      enter(path) {
         rootPath = path;
         path.stop();
       },
     });
+    let result = true;
+
     if (rootPath !== null) {
-      const result = hasReturnStatement(rootPath);
-      expect(result).toBe(true);
+      result = hasReturnStatement(rootPath);
     }
+
+    expect(result).toBe(false);
   });
 
-  test('', () => {
-    const code = 'true';
+  test('wrapped in normal function', () => {
+    const code = `function foo() {
+      return yes;
+    }`;
+
     const ast = parser(code);
     let rootPath: NodePath | null = null;
 
     traverse(ast, {
-      ArrayExpression(path) {
+      // starting from the function declaration so the return statement is wrapped into a function
+      enter(path) {
         rootPath = path;
         path.stop();
       },
     });
+    let result = true;
+
     if (rootPath !== null) {
-      const result = hasReturnStatement(rootPath);
-      expect(result).toBe(false);
+      result = hasReturnStatement(rootPath);
     }
+
+    expect(result).toBe(false);
+  });
+
+  test('in return stament expression', () => {
+    const code = `function foo() {
+      return yes;
+    }`;
+
+    const ast = parser(code);
+    let rootPath: NodePath | null = null;
+
+    traverse(ast, {
+      // starting from the ReturnStatement itself
+      ReturnStatement(path) {
+        rootPath = path;
+        path.stop();
+      },
+    });
+    let result = false;
+
+    if (rootPath !== null) {
+      result = hasReturnStatement(rootPath);
+    }
+
+    expect(result).toBe(true);
+  });
+
+  test('in return statement expression', () => {
+    const code = `function foo() {
+      return yes;
+    }`;
+
+    const ast = parser(code);
+    let rootPath: NodePath | null = null;
+
+    traverse(ast, {
+      // starting from the BlockStatement so the return statement is not wrapped into a fu
+      BlockStatement(path) {
+        rootPath = path;
+        path.stop();
+      },
+    });
+    let result = false;
+
+    if (rootPath !== null) {
+      result = hasReturnStatement(rootPath);
+    }
+
+    expect(result).toBe(true);
+  });
+});
+
+describe('Has no return statement', () => {
+  test('in a random expression', () => {
+    const code = 'yes;';
+
+    const ast = parser(code);
+    let rootPath: NodePath | null = null;
+
+    traverse(ast, {
+      enter(path) {
+        rootPath = path;
+        path.stop();
+      },
+    });
+    let result = true;
+
+    if (rootPath !== null) {
+      result = hasReturnStatement(rootPath);
+    }
+
+    expect(result).toBe(false);
   });
 });

--- a/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-return-statement/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/utils/contraints/has-return-statement/index.ts
@@ -20,6 +20,9 @@ import type { NodePath } from '@babel/traverse';
  * }
  */
 export const hasReturnStatement: Constraint = (path) => {
+  // Problematic when
+  // 1. The path directly represents a return statement.
+  // 2. The path contains a return statement that isn't nested within any type of function.
   let problematic = false;
 
   if (path.isReturnStatement()) {
@@ -31,11 +34,12 @@ export const hasReturnStatement: Constraint = (path) => {
       let parent: NodePath | null = innerPath;
       let isWrapped = false;
       while (!isWrapped && parent) {
-        if (isAFunction(path)) {
+        if (isAFunction(parent)) {
           isWrapped = true;
         }
         parent = parent === path ? null : parent.parentPath;
       }
+      // If the return statement is not wrapped in a function, it is problematic.
       if (!problematic && !isWrapped) {
         problematic = true;
       }


### PR DESCRIPTION
This PR fixes the hasReturnStatement constraint in the slimfast-node package to correctly check the parent path when traversing upwards.