### PR TITLE
[slimfast-node]: Make Visitor an abstract class

### DIFF
--- a/.changeset/sharp-news-judge.md
+++ b/.changeset/sharp-news-judge.md
@@ -1,0 +1,5 @@
+---
+"@modular-rocks/slimfast-node": patch
+---
+
+Chore: Makes Visitor an abstract class

--- a/packages/slimfast-node/src/slimfast/index.ts
+++ b/packages/slimfast-node/src/slimfast/index.ts
@@ -9,6 +9,7 @@ import { defaultFunctionNameGenerator } from './pipeline/name/default-function-n
 import { ExpressionVisitor } from './visitors/expression';
 
 import type { SlimFastOpts } from '../types';
+import type { Visitor } from './visitors/visitor';
 
 /**
  * It represents a workspace that contains both the original and refactored
@@ -48,8 +49,7 @@ export class SlimFast extends SlimFastBase {
    */
   defaultOptions(opts: SlimFastOpts) {
     super.defaultOptions(opts);
-    // TODO: Use better types for visitors
-    const visitors: any[] = opts.visitors || [ExpressionVisitor];
+    const visitors: (typeof Visitor)[] = opts.visitors || [ExpressionVisitor];
     const namer = opts.namer || defaultFunctionNameGenerator(0);
     const builder = opts.builder || pipelineBuilder;
     const pipeline = opts.pipeline?.length

--- a/packages/slimfast-node/src/slimfast/pipeline/extract/index.ts
+++ b/packages/slimfast-node/src/slimfast/pipeline/extract/index.ts
@@ -33,7 +33,7 @@ type Namer = (path: NodePath, data: RandomObject, options: Options) => void;
  * const processedFile = extract(myVisitors)(file, extractionOptions, state, workspace);
  */
 export const extract =
-  (visitors: Visitor[]) =>
+  (visitors: (typeof Visitor)[]) =>
   /**
    * Processes a file's Abstract Syntax Tree (AST) to extract nodes based on the provided visitor patterns.
    *

--- a/packages/slimfast-node/src/slimfast/visitors/visitor/index.ts
+++ b/packages/slimfast-node/src/slimfast/visitors/visitor/index.ts
@@ -15,7 +15,7 @@ import type { NodePath, Node } from '@babel/traverse';
  * The Visitor class is responsible for traversing the AST and managing extraction based on
  * provided constraints and blocklisted parent types.
  */
-export class Visitor {
+export abstract class Visitor {
   /**
    * A map storing extracted nodes from the AST.
    */
@@ -84,9 +84,7 @@ export class Visitor {
    *   return [isIdentifier];
    * }
    */
-  constraints(): Constraints {
-    return [];
-  }
+  abstract constraints(): Constraints;
 
   /**
    * Provides a list of blocklisted parent node types that should be avoided during AST traversal.
@@ -191,11 +189,7 @@ export class Visitor {
    *   };
    * }
    */
-  visit(): RandomObject {
-    // TODO: maybe use composition to fix this
-    console.warn('Override this method, this is just an example');
-    return {};
-  }
+  abstract visit(): RandomObject;
 
   /**
    * Initiates the traversal of the Abstract Syntax Tree (AST) using the provided visitor methods.

--- a/packages/slimfast-node/src/types.ts
+++ b/packages/slimfast-node/src/types.ts
@@ -1,6 +1,6 @@
 import type { Builder } from './slimfast/pipeline/build/builder';
 import type { NamerGenerator } from './slimfast/pipeline/name/default-function-name-generator';
-import type { ExpressionVisitor } from './slimfast/visitors/expression';
+import type { Visitor } from './slimfast/visitors/visitor';
 import type { Binding, NodePath } from '@babel/traverse';
 import type { Node, Statement } from '@babel/types';
 import type { CodebaseOpts } from '@modular-rocks/workspace-node/types';
@@ -97,7 +97,7 @@ export type ConstraintData<
 export type Constraints = (Constraint | ConstraintWithData)[];
 
 export type SlimFastOpts = CodebaseOpts & {
-  visitors?: ExpressionVisitor[];
+  visitors?: (typeof Visitor)[];
   namer?: NamerGenerator;
   builder?: Builder;
 };
@@ -113,3 +113,9 @@ export type ProvisionalFile = {
   ast: RandomObject;
   import: Statement;
 };
+
+export type {
+  builder,
+  BuilderData,
+  BuilderOpts,
+} from './slimfast/pipeline/build/builder';


### PR DESCRIPTION
This PR updates the `Visitor` class in the `slimfast-node` package to be an abstract class. This change ensures that `Visitor` cannot be instantiated directly and provides a clearer structure for classes that extend `Visitor`. Additionally, it includes an abstract method that must be implemented by any subclass, further enforcing the intended use of the class hierarchy.
